### PR TITLE
Optimize `bürgergeld__in_anderer_bg_als_kindergeldempfänger`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 ## Unreleased
 
+- {gh}`1076` Optimize `bürgergeld__in_anderer_bg_als_kindergeldempfänger`
+  ({ghuser}`JuergenWiemers`)
+
 - {gh}`1072` How-to guide for `plot.dag.tt` ({ghuser}`hmgaudecker`)
 
 ## v1.0a2 — 2025-08-09

--- a/src/gettsim/germany/arbeitslosengeld_2/kindergeldübertrag.py
+++ b/src/gettsim/germany/arbeitslosengeld_2/kindergeldübertrag.py
@@ -134,15 +134,11 @@ def in_anderer_bg_als_kindergeldempfänger(
     """True if the person is in a different Bedarfsgemeinschaft than the
     Kindergeldempfänger of that person.
     """
-    # Create a mask for the kindergeld__p_id_empfänger
-    # Map each kindergeld__p_id_empfänger to its corresponding bg_id
-    empf_bg_id = join(
+    bg_id_empfänger = join(
         foreign_key=kindergeld__p_id_empfänger,
         primary_key=p_id,
         target=bg_id,
         value_if_foreign_key_is_missing=-1,
         xnp=xnp,
     )
-
-    # Compare bg_id array with the mapped bg_ids of kindergeld__p_id_empfänger
-    return empf_bg_id != bg_id
+    return bg_id_empfänger != bg_id

--- a/src/gettsim/germany/arbeitslosengeld_2/kindergeldübertrag.py
+++ b/src/gettsim/germany/arbeitslosengeld_2/kindergeldübertrag.py
@@ -134,17 +134,15 @@ def in_anderer_bg_als_kindergeldempfänger(
     """True if the person is in a different Bedarfsgemeinschaft than the
     Kindergeldempfänger of that person.
     """
-    # Get the array index for all p_ids of empfängers
-    p_id_empfänger_loc = kindergeld__p_id_empfänger
-    for i in range(p_id.shape[0]):
-        p_id_empfänger_loc = xnp.where(
-            kindergeld__p_id_empfänger == p_id[i],
-            i,
-            p_id_empfänger_loc,
-        )
-
+    # Create a mask for the kindergeld__p_id_empfänger
     # Map each kindergeld__p_id_empfänger to its corresponding bg_id
-    empf_bg_id = bg_id[p_id_empfänger_loc]
+    empf_bg_id = join(
+        foreign_key=kindergeld__p_id_empfänger,
+        primary_key=p_id,
+        target=bg_id,
+        value_if_foreign_key_is_missing=-1,
+        xnp=xnp,
+    )
 
     # Compare bg_id array with the mapped bg_ids of kindergeld__p_id_empfänger
     return empf_bg_id != bg_id

--- a/src/gettsim/germany/bürgergeld/kindergeldübertrag.py
+++ b/src/gettsim/germany/bürgergeld/kindergeldübertrag.py
@@ -119,15 +119,11 @@ def in_anderer_bg_als_kindergeldempfänger(
     """True if the person is in a different Bedarfsgemeinschaft than the
     Kindergeldempfänger of that person.
     """
-    # Create a mask for the kindergeld__p_id_empfänger
-    # Map each kindergeld__p_id_empfänger to its corresponding bg_id
-    empf_bg_id = join(
+    bg_id_empfänger = join(
         foreign_key=kindergeld__p_id_empfänger,
         primary_key=p_id,
         target=bg_id,
         value_if_foreign_key_is_missing=-1,
         xnp=xnp,
     )
-
-    # Compare bg_id array with the mapped bg_ids of kindergeld__p_id_empfänger
-    return empf_bg_id != bg_id
+    return bg_id_empfänger != bg_id

--- a/src/gettsim/germany/bürgergeld/kindergeldübertrag.py
+++ b/src/gettsim/germany/bürgergeld/kindergeldübertrag.py
@@ -119,17 +119,15 @@ def in_anderer_bg_als_kindergeldempfänger(
     """True if the person is in a different Bedarfsgemeinschaft than the
     Kindergeldempfänger of that person.
     """
-    # Get the array index for all p_ids of empfängers
-    p_id_empfänger_loc = kindergeld__p_id_empfänger
-    for i in range(p_id.shape[0]):
-        p_id_empfänger_loc = xnp.where(
-            kindergeld__p_id_empfänger == p_id[i],
-            i,
-            p_id_empfänger_loc,
-        )
-
+    # Create a mask for the kindergeld__p_id_empfänger
     # Map each kindergeld__p_id_empfänger to its corresponding bg_id
-    empf_bg_id = bg_id[p_id_empfänger_loc]
+    empf_bg_id = join(
+        foreign_key=kindergeld__p_id_empfänger,
+        primary_key=p_id,
+        target=bg_id,
+        value_if_foreign_key_is_missing=-1,
+        xnp=xnp,
+    )
 
     # Compare bg_id array with the mapped bg_ids of kindergeld__p_id_empfänger
     return empf_bg_id != bg_id

--- a/src/gettsim/germany/ids.py
+++ b/src/gettsim/germany/ids.py
@@ -132,8 +132,7 @@ def sgb_ii_fg_id_formula(
         isin = xnp.isin
 
     children = isin(sorted_p_id, sorted_p_id_elternteil_1) | isin(
-        sorted_p_id,
-        sorted_p_id_elternteil_2,
+        sorted_p_id, sorted_p_id_elternteil_2
     )
 
     # Assign the same fg_id to everybody who has an Einstandspartner,

--- a/src/gettsim/germany/ids.py
+++ b/src/gettsim/germany/ids.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import functools
+from typing import TYPE_CHECKING, Literal
 
 from gettsim.germany import WARNING_MSG_FOR_GETTSIM_BG_ID_WTHH_ID_ETC
 from gettsim.tt import group_creation_function, policy_input
@@ -53,11 +54,12 @@ def fg_id_arbeitslosengeld_2(
     familie__p_id_elternteil_1: IntColumn,
     familie__p_id_elternteil_2: IntColumn,
     xnp: ModuleType,
+    backend: Literal["numpy", "jax"],
 ) -> IntColumn:
     """Familiengemeinschaft. Base unit for some transfers.
 
     Maximum of two generations, the relevant base unit for Bürgergeld / Arbeitslosengeld
-    2, before excluding children who have enough income fend for themselves.
+    2, before excluding children who have enough income to fend for themselves.
     """
     return sgb_ii_fg_id_formula(
         p_id_einstandspartner=arbeitslosengeld_2__p_id_einstandspartner,
@@ -67,6 +69,7 @@ def fg_id_arbeitslosengeld_2(
         p_id_elternteil_1=familie__p_id_elternteil_1,
         p_id_elternteil_2=familie__p_id_elternteil_2,
         xnp=xnp,
+        backend=backend,
     )
 
 
@@ -79,11 +82,12 @@ def fg_id_bürgergeld(
     familie__p_id_elternteil_1: IntColumn,
     familie__p_id_elternteil_2: IntColumn,
     xnp: ModuleType,
+    backend: Literal["numpy", "jax"],
 ) -> IntColumn:
     """Familiengemeinschaft. Base unit for some transfers.
 
     Maximum of two generations, the relevant base unit for Bürgergeld / Arbeitslosengeld
-    2, before excluding children who have enough income fend for themselves.
+    2, before excluding children who have enough income to fend for themselves.
     """
     return sgb_ii_fg_id_formula(
         p_id_einstandspartner=bürgergeld__p_id_einstandspartner,
@@ -93,6 +97,7 @@ def fg_id_bürgergeld(
         p_id_elternteil_1=familie__p_id_elternteil_1,
         p_id_elternteil_2=familie__p_id_elternteil_2,
         xnp=xnp,
+        backend=backend,
     )
 
 
@@ -104,6 +109,7 @@ def sgb_ii_fg_id_formula(
     p_id_elternteil_1: IntColumn,
     p_id_elternteil_2: IntColumn,
     xnp: ModuleType,
+    backend: Literal["numpy", "jax"],
 ) -> IntColumn:
     """Formula to compute the FG ID for SGB II transfers"""
     n = xnp.max(p_id) + 1
@@ -118,7 +124,14 @@ def sgb_ii_fg_id_formula(
     sorted_p_id_elternteil_2 = p_id_elternteil_2[sorting]
     sorted_p_id_einstandspartner = p_id_einstandspartner[sorting]
 
-    children = xnp.isin(sorted_p_id, sorted_p_id_elternteil_1) | xnp.isin(
+    # Necessary because JAX's `isin` uses keyword `method` instead of NumPy's `kind`
+    # See https://github.com/ttsim-dev/ttsim/pull/41#issuecomment-3180607171
+    if backend == "jax":
+        isin = functools.partial(xnp.isin, method="sort")
+    else:
+        isin = xnp.isin
+
+    children = isin(sorted_p_id, sorted_p_id_elternteil_1) | isin(
         sorted_p_id,
         sorted_p_id_elternteil_2,
     )


### PR DESCRIPTION
"Twin PR" to https://github.com/ttsim-dev/ttsim/pull/41. Uses the optimized `tt.shared.join` in that PR. 

[**EDIT**: Just realized I need to change this twice, once for "bürgergeld" and once for "arbeitslosengeld_2".]

[**EDIT2**: I added the blocked label because this should only be merged after [ttsim#41](https://github.com/ttsim-dev/ttsim/pull/41) is accepted. It really wouldn't help to use the very inefficient current implementation of `tt.shared.join`. 😅]

[**EDIT3**: Pushed a commit to fix the quadratic memory scaling for JAX, as discussed in https://github.com/ttsim-dev/ttsim/pull/41]
