### PR TITLE
Fix typos in docs and param yamls

### DIFF
--- a/docs/tutorials/simple_example.ipynb
+++ b/docs/tutorials/simple_example.ipynb
@@ -284,7 +284,7 @@
     "\n",
     "# Edit the leafs in the template and then read it back in\n",
     "with PATH_FOR_TEMPLATE.open(\"r\") as f:\n",
-    "    MAPPER = {yaml.load(f, allow_unicode=True)}\n",
+    "    MAPPER = yaml.safe_load(f)\n",
     "```"
    ]
   },

--- a/src/gettsim/germany/sozialversicherung/rente/altersrente/besonders_langjährig/altersgrenze.yaml
+++ b/src/gettsim/germany/sozialversicherung/rente/altersrente/besonders_langjährig/altersgrenze.yaml
@@ -69,7 +69,7 @@ altersgrenze_gestaffelt:
   2014-06-23:
     reference: RV-Leistungsverbesserungsgesetz 2014. BGBl. I S. 787 2014
     first_year_to_consider: 1900
-    last_year_to_consider: 2031
+    last_year_to_consider: 2030
     1952:
       years: 63
       months: 0

--- a/src/gettsim/germany/sozialversicherung/rente/altersrente/für_frauen/altersgrenze.yaml
+++ b/src/gettsim/germany/sozialversicherung/rente/altersrente/für_frauen/altersgrenze.yaml
@@ -58,7 +58,7 @@ altersgrenze_gestaffelt:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of full retirement age from 60 to 65 for birth cohort 1941-1952.
     first_year_to_consider: 1900
-    last_year_to_consider: 2029
+    last_year_to_consider: 2030
     1940:
       12:
         years: 60
@@ -259,7 +259,7 @@ altersgrenze_gestaffelt:
     reference: Wachstums- und Beschäftigungsförderungsgesetz 1996. BGBl. I S. 1461
     note: Increase of FRA accelerated with exemption (Vertrauensschutz).
     first_year_to_consider: 1900
-    last_year_to_consider: 2029
+    last_year_to_consider: 2030
     1939:
       12:
         years: 60
@@ -502,7 +502,7 @@ altersgrenze_vorzeitig_gestaffelt:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of early retirement age from 60 to 62 for birth cohort 1949-1952.
     first_year_to_consider: 1900
-    last_year_to_consider: 2029
+    last_year_to_consider: 2030
     1948:
       12:
         years: 60

--- a/src/gettsim/germany/sozialversicherung/rente/altersrente/regelaltersrente/altersgrenze.yaml
+++ b/src/gettsim/germany/sozialversicherung/rente/altersrente/regelaltersrente/altersgrenze.yaml
@@ -53,7 +53,7 @@ altersgrenze_gestaffelt:
       Altersteilzeit before January 1st, 2007 or received "Anpassungsgeld für
       entlassene Arbeitnehmer des Bergbaus".
     first_year_to_consider: 1900
-    last_year_to_consider: 2031
+    last_year_to_consider: 2030
     1946:
       years: 65
       months: 0

--- a/src/gettsim/germany/sozialversicherung/rente/altersrente/wegen_arbeitslosigkeit/altersgrenze.yaml
+++ b/src/gettsim/germany/sozialversicherung/rente/altersrente/wegen_arbeitslosigkeit/altersgrenze.yaml
@@ -43,7 +43,7 @@ altersgrenze_gestaffelt:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of full retirement age from 60 to 65 for birth cohort 1941-1952.
     first_year_to_consider: 1900
-    last_year_to_consider: 2029
+    last_year_to_consider: 2030
     1940:
       12:
         years: 60
@@ -241,7 +241,7 @@ altersgrenze_gestaffelt:
     reference: Ruhestandsförderungsgesetz 1996. BGBl. I S. 1078 1996.
     note: Increase of full retirement age from 60 to 65 for birth cohort 1937-1952.
     first_year_to_consider: 1900
-    last_year_to_consider: 2029
+    last_year_to_consider: 2030
     1936:
       12:
         years: 60
@@ -441,7 +441,7 @@ altersgrenze_gestaffelt:
     reference: Wachstums- und Beschäftigungsförderungsgesetz 1996. BGBl. I S. 1461 1996
     note: Increase of full retirement age from 60 to 65 for birth cohort 1937-1941.
     first_year_to_consider: 1900
-    last_year_to_consider: 2029
+    last_year_to_consider: 2030
     1936:
       12:
         years: 60
@@ -661,7 +661,7 @@ altersgrenze_gestaffelt_vertrauensschutz:
       the subsequent Wachstums- und Beschäftigungsförderungsgesetz 1996. BGBl. I S. 1461
       1996.
     first_year_to_consider: 1900
-    last_year_to_consider: 2029
+    last_year_to_consider: 2030
     1940:
       12:
         years: 60
@@ -765,7 +765,7 @@ altersgrenze_vorzeitig_gestaffelt:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of early retirement age from 60 to 62 for birth cohort 1949-1952.
     first_year_to_consider: 1900
-    last_year_to_consider: 2029
+    last_year_to_consider: 2030
     1948:
       12:
         years: 60
@@ -850,7 +850,7 @@ altersgrenze_vorzeitig_gestaffelt:
     reference: Ruhestandsförderungsgesetz 1996. BGBl. I S. 1078 1996.
     note: Increase of early retirement age as before. (§ 237 SGB VI  Abs.5).
     first_year_to_consider: 1900
-    last_year_to_consider: 2029
+    last_year_to_consider: 2030
     1948:
       12:
         years: 60
@@ -938,7 +938,7 @@ altersgrenze_vorzeitig_gestaffelt:
     reference: RV-Nachhaltigkeitsgesetz 2004. BGBl. I S. 1791 2004
     note: Increase of the early retirement age from 60 to 63 for birth cohort 1946-1948.
     first_year_to_consider: 1900
-    last_year_to_consider: 1951
+    last_year_to_consider: 2030
     1945:
       12:
         years: 60


### PR DESCRIPTION
### What problem do you want to solve?

- The yaml dump/load example was slightly wrong in `simple_examples.ipynb` (discovered by @felixschmitz)
- The lookup table for the threshold age of one phased-out pathway into retirement ends with birth year 1951. It should be much longer because we take care of eligibility checks elsewhere. 
