### PR TITLE
GEP 10: clarify units, group calculations, and validation guarantees

### DIFF
--- a/docs/geps/gep-10.md
+++ b/docs/geps/gep-10.md
@@ -1,6 +1,6 @@
 (gep-10)=
 
-# GEP 10 — Value Types, Units, Grain, and Currency
+# GEP 10 — Units and Dimensionality
 
 ```{list-table}
 - * Author
@@ -17,36 +17,31 @@
 
 ## Abstract
 
-This GEP introduces a static value-type system for every node, parameter, input,
-generated operation, and result in TTSIM and GETTSIM. A value type records several
-independent facts:
+This GEP introduces explicit units for nodes, parameters, inputs, generated operations,
+rounding specifications, and results in TTSIM and GETTSIM. A unit records what a value
+measures, whether it is a stock or a flow, its reference period, and, for a restricted
+class of measurable group quantities, the group to which it belongs. Examples are Euros
+per month, square meters per household, and persons per Bedarfsgemeinschaft.
 
-1. its physical unit;
-1. its policy reference-period signature and conversion convention;
-1. its semantic kind, such as number, boolean, share, count, identifier, or category;
-1. the entity the value describes and the row domain on which it is represented;
-1. any additional named tensor axes;
-1. whether the value is extensive, intensive, statistic-derived, or a neutral modifier;
-1. any calendar-point, duration, or ordinal semantics;
-1. its currency denomination and provenance; and
-1. whether it may be missing.
+TTSIM uses these declarations as a **bounded dimensional linter**. During policy-
+environment assembly, it evaluates supported policy-function expressions with
+unit-carrying placeholders and rejects incompatible arithmetic. It can detect, for
+example, addition of a monthly monetary amount to a yearly monetary amount, use of a
+currency stock as a branch condition, or a function that declares monthly income but
+returns wealth multiplied by a bare share.
 
-These axes are deliberately not collapsed into one Pint expression. Pint is responsible
-only for physical-unit algebra and physical conversion. Policy periods, grouping levels,
-identifiers, booleans, counts, storage grain, tensor axes, calendar ordinals, extensity,
-and currency provenance are separate type components with separate rules.
+The checker is not a proof of arbitrary Python, data alignment, legal correctness, or
+semantic correctness among dimensionless values. In particular, it does not generally
+distinguish shares, identifiers, categories, counts, and rates that have the same Pint
+dimensionality. Grouping-level denominators are a deliberately restricted guard for
+measurable group quantities, not a complete model of relational data grain. Operations
+whose unit-relevant behavior the checker cannot derive must fail closed or be covered by
+an explicit, reported exception.
 
-TTSIM validates declarations, graph edges, supported policy-function bodies, joins,
-aggregations, reductions, schedules, date regimes, rounding rules, and typed data
-boundaries. The body checker is a conservative abstract interpreter over a documented
-Python subset. It is not described as executing a proof of arbitrary Python. Every
-active node and date regime receives an auditable evidence status, and every assertion
-or exemption is reported separately from verified code.
-
-For historical currencies, each policy regime is evaluated in the statutory denomination
-in which its parameters and coefficients are written. Input and output conversion occurs
-at explicit boundaries. Coefficients with inverse-currency or period units declare those
-units; statutory-currency evaluation is not a substitute for dimensional correctness.
+Unit declarations also make historical currency handling explicit. Each policy regime
+has exactly one statutory computation currency. GETTSIM evaluates statutory parameters
+and rounding rules in that currency, converts monetary input at the boundary, and
+converts computed results only after statutory computation and rounding.
 
 ## Normative language
 
@@ -59,63 +54,75 @@ capital letters.
 
 ## Motivation and scope
 
-TTSIM policy code currently manipulates ordinary Python, NumPy, and JAX values. Runtime
-dtypes can distinguish integers, floating-point numbers, and booleans, but they cannot
-by themselves distinguish monthly income from wealth, a household total from a person
-amount, a household ID from a tax-unit ID, a calendar year from an age, or a share from
-a count.
+Four problems motivate this GEP.
 
-A reliable validation system must address six independent problem classes.
+1. **Arithmetic is not dimensionally validated.** TTSIM currently manipulates ordinary
+   Python, NumPy, and JAX values. A calculation can therefore add total rent to rent per
+   square meter or return a stock from a function that declares a monthly flow.
+1. **Selected grouping mistakes are not caught.** A household total and a
+   Bedarfsgemeinschaft total can be combined without an explicit conversion. A missing
+   division by a group head count can likewise remain invisible.
+1. **Historical currencies need one explicit convention.** Some historical monetary
+   parameters are specified in Deutsche Mark and others in Euro. Statutory numerical
+   values must not be silently rewritten merely to make every policy year use the same
+   denomination.
+1. **Reference-period conversions are maintained separately.** GETTSIM already converts
+   between annual, quarterly, monthly, weekly, and daily flows. The ordinary conversion
+   ratios should come from the same unit system that checks the policy expressions.
 
-1. **Physical and period consistency.** Arithmetic must reject incompatible physical
-   measures and incompatible policy reference periods. A stock of wealth must not
-   silently become a monthly flow. Rent per square meter must not be added to total
-   rent.
-1. **Semantic-kind consistency.** A boolean, identifier, category, share, probability,
-   rate, count, and unrestricted number are not interchangeable merely because each can
-   be stored in an integer or floating-point array.
-1. **Relational, grain, and axis consistency.** Group membership, keys, row domains,
-   broadcast values, joins, cardinality, aggregation, and local tensor axes are
-   structural properties. They are not physical dimensions and must not be represented
-   as Pint denominators.
-1. **Extensity consistency.** Sums, means, extrema, counts, and per-capita
-   transformations have different semantics. A mean remains a statistic of the target
-   group; it does not become a person-level value because a symbolic group denominator
-   happened to cancel.
-1. **Calendar consistency.** Absolute dates, year points, year-month points, durations,
-   month-of-year ordinals, and day-of-month ordinals support different operations. In
-   particular, February and the fifteenth day are not context-free affine points.
-1. **Currency and provenance consistency.** A monetary value has a physical currency
-   dimension, a denomination, an origin or effective-date rule, and an ordering relative
-   to statutory rounding. Historical statutory coefficients may have inverse-currency
-   units even when the law prints them as bare numbers.
+The adopted design is intentionally narrower than a general static value-type system. It
+covers:
 
-This GEP covers:
+- compositional Pint units for physical quantities, reference periods, and restricted
+  grouping-level markers;
+- declarations on policy functions, policy inputs, parameters, schedules, structured
+  values, generated nodes, aggregations, rounding rules, and optional input tags;
+- bounded body checking for the documented expression subset;
+- explicit handling of truth contexts, `xnp.where`, joins, and unsupported reductions;
+- validation over every distinct function, parameter, and statutory-currency regime;
+- one statutory computation currency per policy regime; and
+- separate reporting of declarations, checked bodies, casts, and whole-body opt-outs.
 
-- the canonical static type of scalar and array leaves, plus compound structure and
-  mapping types;
-- declarations on policy functions, policy inputs, parameters, structured values,
-  schedules, rounding specifications, generated nodes, and typed data;
-- type rules for supported scalar and vectorized expressions;
-- relational operations, including joins, gathers, broadcasts, allocations, and
-  aggregations;
-- policy reference-period conversion;
-- calendar types and operations;
-- statutory and data currency handling;
-- validation over every distinct policy-date regime;
-- evidence, coverage, exceptions, and conformance requirements; and
-- the migration of TTSIM, METTSIM, and GETTSIM.
+The GEP does **not** attempt to establish:
 
-The GEP does **not** claim to prove that a policy formula implements the law, that a
-numerical algorithm is stable, that values are finite, or that arbitrary Python is safe.
-It provides a sound static contract for the documented expression language and explicit
-evidence for the parts it cannot verify.
+- that a policy formula implements the statute or an economic model correctly;
+- semantic distinctions among all dimensionless values, such as an identifier, share,
+  category, probability, count, or unrestricted scalar;
+- nominal key domains, uniqueness, join cardinality, row alignment, broadcasting
+  provenance, or general storage grain;
+- numerical stability, finiteness, overflow safety, or economically admissible ranges;
+- correctness of arbitrary Python or third-party functions; or
+- statutory day-count, partial-period, or compounding conventions beyond the existing
+  generated reference-period conversions.
 
-The naming conventions and generated period conversions in {ref}`GEP 1 <gep-1>`,
-grouping and identifier declarations in {ref}`GEP 2 <gep-2>`, DAG and aggregation
+The naming conventions and generated reference-period conversions in
+{ref}`GEP 1 <gep-1>`, grouping declarations in {ref}`GEP 2 <gep-2>`, DAG and aggregation
 concepts in {ref}`GEP 4 <gep-4>`, rounding in {ref}`GEP 5 <gep-5>`, and runtime
-user/canonical type split in {ref}`GEP 9 <gep-9>` remain in force except where this GEP
-explicitly refines them.
+user/canonical type split in {ref}`GEP 9 <gep-9>` remain in force.
+
+(gep-10-guarantee)=
+
+### What a successful check means
+
+A successful GEP-10 body check means only the following:
+
+> For every explored path through a supported policy-function body, every operation for
+> which TTSIM supplies a unit rule is dimensionally compatible, and every explored
+> return value is compatible with the function's declared unit.
+
+This statement is conditional on the declared units of inputs and parameters being
+correct, on the checker reaching every relevant path within its documented bounds, and
+on every called operation being represented by a faithful validator stand-in.
+
+A successful environment check MUST NOT be described simply as a proof that “all
+functions are unit-correct.” Documentation and CI output MUST distinguish at least:
+
+- required declarations that were resolved;
+- function bodies that were checked;
+- generated nodes whose units were derived from a documented rule;
+- local uses of `cast_ttsim_unit`;
+- function bodies excluded with `verify_units=False`; and
+- bodies rejected because they use an unsupported operation.
 
 (gep-10-usage)=
 
@@ -123,13 +130,10 @@ explicitly refines them.
 
 ### Users of existing policy environments
 
-Users may continue to call `main()` with ordinary arrays, mappings, or a DataFrame.
-Untyped data remain supported, but the resulting evidence report records that their
-non-dtype semantics were **assumed from the policy node**, not independently verified
-from the input.
-
-A user may select the denomination of untyped monetary input and computed output with
-`data_currency`. The default for GETTSIM remains Euro.
+Most users continue to call `main()` with ordinary arrays, mappings, or a DataFrame.
+Users may provide a `data_currency` argument to specify the denomination assumed for
+unannotated monetary input and requested for computed monetary results. The default in
+GETTSIM remains Euro.
 
 ```python
 results = main(
@@ -141,265 +145,211 @@ results = main(
 
 For this run, GETTSIM:
 
-1. resolves the 1999 policy environment and its complete value types;
-1. converts monetary input from Euro to the statutory 1999 denomination;
-1. evaluates the policy using statutory parameters and coefficients without rewriting
-   their legal numerical values;
-1. applies statutory rounding in the concrete denomination declared by each rounding
-   rule; and
-1. converts computed monetary results to Euro after statutory computation is complete.
+1. identifies Deutsche Mark as the statutory computation currency on 1999-01-01;
+1. converts currency-denominated input from Euro to Deutsche Mark;
+1. evaluates the policy using statutory Deutsche-Mark parameters and rounding rules;
+1. performs statutory rounding before presentation conversion; and
+1. converts computed monetary results back to Euro.
 
-Requested raw inputs are returned unchanged. Requested parameters retain their statutory
-currency and provenance unless the caller explicitly asks for a converted presentation
-value.
+Requested raw input columns are returned unchanged. Requested parameters retain their
+statutory currency. A policy function never receives simultaneous DM- and
+EUR-denominated monetary quantities within one policy regime.
 
 (gep-10-trees)=
 
-### Fully typed input and output
+(gep-10-boundary)=
 
-Users who want the input boundary checked may wrap every leaf in `TypedColumn`. The
-wrapper contains ordinary values and a complete source `ValueSpec`.
+### Unit-annotated data
+
+Input unit annotations are optional. They are useful when users want to state the source
+currency and reference period of their data. When this input mode is selected, every
+leaf is wrapped in `UnitAnnotatedColumn`, including identifiers and dimensionless
+columns.
 
 ```python
 from gettsim import InputData, MainTarget, TTTargets, main
-from gettsim.tt import Entity, Extensity, Index, Key, Period, Q, TypedColumn
+from gettsim.tt import TTSIMUnit, UnitAnnotatedColumn
 
 input_tree = {
-    "p_id": TypedColumn(
+    "p_id": UnitAnnotatedColumn(
         values=[0, 1],
-        value_type=Q.identifier(Key.P_ID),
+        unit=TTSIMUnit.DIMENSIONLESS,
     ),
-    "bg_id": TypedColumn(
+    "bg_id": UnitAnnotatedColumn(
         values=[0, 0],
-        value_type=Q.identifier(Key.BG_ID),
+        unit=TTSIMUnit.DIMENSIONLESS,
     ),
-    "geburtsjahr": TypedColumn(
+    "geburtsjahr": UnitAnnotatedColumn(
         values=[1980, 2015],
-        value_type=Q.calendar_year_point(
-            subject=Entity.PERSON,
-            index=Index.unique(Entity.PERSON),
-        ),
+        unit=TTSIMUnit.CALENDAR_YEAR,
     ),
-    "einkommen_m": TypedColumn(
+    "einkommen_m": UnitAnnotatedColumn(
         values=[2000.0, 0.0],
-        value_type=Q.money(
-            period=Period.per_month(),
-            subject=Entity.PERSON,
-            extensity=Extensity.EXTENSIVE,
-            currency="EUR",
-            index=Index.unique(Entity.PERSON),
-        ),
+        unit=TTSIMUnit.EUR.PER_MONTH,
     ),
 }
 
 results = main(
-    main_target=MainTarget.results.tree_with_value_types,
+    main_target=MainTarget.results.tree_with_unit_annotations,
     policy_date_str="2025-01-01",
-    input_data=InputData.tree_with_value_types(input_tree),
+    input_data=InputData.tree_with_unit_annotations(input_tree),
     tt_targets=TTTargets(tree={"transfer": {"betrag_m": None}}),
 )
 ```
 
-The boundary requires exact agreement on semantic kind, subject, extensity, calendar
-semantics, key domain, and compatible index and local-axis representation. Physical
-units and period specifications must be compatible or connected by registered
-conversions. A concrete input currency may differ from the computation currency and is
-converted at the boundary. A key domain, boolean kind, category domain, or subject grain
-is never converted.
+The boundary behavior is deliberately limited and MUST be described exactly:
 
-`MainTarget.results.tree_with_value_types` returns each computed leaf as a `TypedColumn`
-with the fully resolved value type and concrete output denomination. Ordinary result
-targets continue to return bare values.
+- a tag built from an unknown unit token fails;
+- the tag's period MUST match the column's GEP-1 time suffix exactly;
+- a concrete source currency may differ from the run's statutory currency and is
+  converted; and
+- other physical dimensions and grouping levels are not, in this first implementation,
+  compared with the corresponding node declaration at the input boundary.
 
-### Contributors: policy functions and inputs
+Thus a `_m` column tagged per year fails, but the boundary alone does not establish that
+an unsuffixed age column was not incorrectly tagged as currency. The function and node
+declarations remain the source of the computation's units. Unit-annotated input is a
+currency-and-period guard, not a fully typed data interface.
 
-A policy function declares a `value_type`, not a single compositional unit token.
+When `MainTarget.results.tree_with_unit_annotations` is requested, computed result
+leaves carry their resolved unit and concrete output currency. Ordinary result targets
+continue to return bare values.
+
+### Contributors and users extending policy environments
+
+Contributors adding functions to a policy environment declare units on policy functions,
+policy inputs, parameters, rounding specifications, and hand-written aggregations.
+
+#### Policy functions
+
+A policy function declares the unit of its return value. TTSIM checks the supported
+parts of the function body against that declaration when the policy environment is
+assembled.
 
 ```python
-from ttsim.tt import Entity, Extensity, Period, Q
-
-
-@policy_input(
-    value_type=Q.money(
-        period=Period.per_month(),
-        subject=Entity.BG,
-        extensity=Extensity.EXTENSIVE,
-    )
-)
+@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_BG)
 def regelsatz_m_bg() -> float: ...
 
 
-@policy_input(
-    value_type=Q.money(
-        period=Period.per_month(),
-        subject=Entity.BG,
-        extensity=Extensity.EXTENSIVE,
-    )
-)
+@policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_BG)
 def mehrbedarf_m_bg() -> float: ...
 
 
-@policy_function(
-    value_type=Q.money(
-        period=Period.per_month(),
-        subject=Entity.BG,
-        extensity=Extensity.EXTENSIVE,
-    )
-)
-def betrag_m_bg(regelsatz_m_bg: float, mehrbedarf_m_bg: float) -> float:
+@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_BG)
+def betrag_m_bg(
+    regelsatz_m_bg: float,
+    mehrbedarf_m_bg: float,
+) -> float:
     return regelsatz_m_bg + mehrbedarf_m_bg
 ```
 
-`Q.money()` uses the abstract `STATUTORY` currency in code-side declarations. At a
-policy date, the policy environment resolves it to the concrete statutory denomination.
-The `_m` suffix must agree with the period signature, and `_bg` must agree with the
-declared subject where GEP 1 says the suffix denotes the subject. Suffixes are
-consistency checks; they do not supply missing type axes and do not encode storage
-layout.
+`CURRENCY` is abstract in code-side declarations. At a policy date, TTSIM replaces it
+with the regime's concrete statutory currency. The `_m` suffix must agree with
+`PER_MONTH`, and `_bg` must agree with `PER_BG` where GEP 1 requires the suffix.
 
-Booleans are declared as booleans, not as dimensionless numbers.
+The following function is rejected because the operands have different physical units:
 
 ```python
-@policy_input(value_type=Q.boolean(subject=Entity.PERSON))
-def eligible() -> bool: ...
+@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+def amount_m() -> float: ...
 
 
-@policy_function(
-    value_type=Q.money(
-        period=Period.per_month(),
-        subject=Entity.PERSON,
-        extensity=Extensity.EXTENSIVE,
-    )
-)
-def transfer_m(eligible: bool, amount_m: float) -> float:
-    return amount_m if eligible else 0
+@policy_input(unit=TTSIMUnit.CURRENCY.PER_SQUARE_METER.PER_MONTH)
+def rent_per_square_meter_m() -> float: ...
+
+
+@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+def incorrect_amount_m(
+    amount_m: float,
+    rent_per_square_meter_m: float,
+) -> float:
+    return amount_m + rent_per_square_meter_m
 ```
 
-The condition is checked as `BOOLEAN`. The zero arm is a typed zero literal that adopts
-the type of `amount_m`. A currency value, ID, count, or category used directly as the
-condition is an error in both scalar and vectorized code.
+(gep-10-periods)=
 
-### Contributors: explicit group operations
+#### Stocks, flows, shares, and rates
 
-Grouping is expressed through typed relations rather than physical-unit denominators.
+A stock has no reference-period denominator. A flow has one. Multiplication by a bare
+share preserves the stock/flow status of the other operand.
 
 ```python
-rent_m_hh = aggregate(
-    rent_m_person,
-    relation=PERSON_TO_HH,
-    how=SUM,
-)
+@policy_input(unit=TTSIMUnit.CURRENCY)
+def wealth() -> float: ...
 
-average_rent_m_hh = mean_per_member(
-    rent_m_hh,
-    count=persons_in_hh,
-    relation=PERSON_TO_HH,
-)
 
-rent_allocation_m_person = allocate_equal(
-    rent_m_hh,
-    count=persons_in_hh,
-    relation=PERSON_TO_HH,
-)
+@policy_function(unit=TTSIMUnit.CURRENCY)
+def retained_wealth(wealth: float) -> float:
+    return 0.8 * wealth
 ```
 
-`rent_m_hh` is an extensive monthly monetary amount with subject `HH`.
-`average_rent_m_hh` is an intensive “per member” statistic that remains a property of
-the household and is stored once per household. `rent_allocation_m_person` is an
-extensive person amount whose allocations sum back to the household total. All three
-retain the physical currency unit and monthly period. No `[hh]` dimension is created or
-cancelled, and storage grain is not confused with allocation incidence.
+The result is a stock because `0.8` is dimensionless. Declaring `retained_wealth` as
+`CURRENCY.PER_MONTH` would be false.
 
-A group value aligned to person rows is produced by a typed gather or broadcast.
+A rate that turns a stock into a flow carries an inverse-period unit:
 
 ```python
-allowance_m_person = gather(
-    foreign_key=hh_id,
-    primary_key=hh_table_id,
-    target=allowance_m_hh,
-    cardinality=MANY_TO_ONE,
-    on_missing=MISSING,
-)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_YEAR)
+def interest_rate_y() -> float: ...
+
+
+@policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
+def interest_income_y(
+    wealth: float,
+    interest_rate_y: float,
+) -> float:
+    return wealth * interest_rate_y
 ```
 
-The key domains, primary-key uniqueness, declared cardinality, missing policy, target
-type, and source and target row domains are validated. A monetary value cannot be used
-as a key, and an `Id[HH]` cannot be joined to an `Id[BG]`.
+The inference is
 
-### Contributors: coefficients with inverse units
+```text
+CURRENCY * (1 / year) = CURRENCY / year.
+```
 
-Statutory evaluation in a concrete currency does not make fitted or statutory
-coefficients dimensionless. Coefficients declare their complete mathematical type.
+The unit system does not infer financial compounding conventions. A linear annual rate
+may be converted to a monthly flow with the ordinary generated period ratio. An
+effective annual return that requires `(1 + r_y) ** (1 / 12) - 1`, a continuously
+compounded rate, or a statute-specific proration MUST use an explicit conversion
+function. Units can establish that a rate is per year; they cannot determine the
+intended rate convention.
+
+#### Parameters
+
+Parameter files record the concrete currency and period in which a statute specifies a
+value.
 
 ```yaml
-wohngeld_coefficients:
-  type: dict
-  value_type:
-    a:
-      unit: one
-      period: stock
-      kind: number
-      subject: global
-      extensity: neutral
-    b:
-      unit: 1 / currency
-      period: month
-      kind: number
-      subject: global
-      extensity: neutral
-      currency: EUR
-    c:
-      unit: 1 / currency ** 2
-      period: month ** 2
-      kind: number
-      subject: global
-      extensity: neutral
-      currency: EUR
+einkommensgrenze_m:
+  unit: EUR_PER_MONTH
+  type: scalar
   2024-01-01:
-    a: 0.04
-    b: 0.0002
-    c: 0.0001
+    value: 1000.0
 ```
 
-Multiplying `b` by an `EUR_PER_MONTH` income, or `c` by the square of that income,
-produces a dimensionless number. Declaring either coefficient as a bare dimensionless
-number is rejected. A later statutory-currency regime supplies new dated coefficient
-values and matching concrete currency declarations.
+Currency-denominated parameters MUST use a concrete currency. Validation requires that
+currency to equal the statutory computation currency for every policy regime in which
+the parameter entry is active.
 
 ## Backward compatibility
 
-This GEP deliberately replaces the one-dimensional compositional-unit model.
-
-- Bare arrays and the DataFrame or mapping interfaces remain supported. Their semantic
-  types are assumed from the policy environment and reported as unverified input
-  assumptions.
-- `data_currency` continues to default to `EUR` in GETTSIM.
-- The legacy `unit=` decorator argument and `TTSIMUnit` builder MAY be supported for one
-  deprecation cycle as a migration adapter. The adapter may recover only the physical
-  unit and a simple standard reference-period signature where that mapping is
-  unambiguous. It MUST NOT infer a period convention, semantic kind, subject, extensity,
-  key or category domain, row index, local tensor axes, calendar semantics, currency
-  provenance, or nullability from a grouping denominator, suffix, runtime dtype, or
-  example value.
-- `PER_HH`, `PER_BG`, and other group suffixes are removed from physical-unit syntax.
-  Grouping is represented by `subject`, `index`, relations, and aggregation metadata.
-- `DIMENSIONLESS` is no longer a sufficient declaration. Contributors must declare
-  whether a value is a number, boolean, share, probability, rate, count, identifier, or
-  category.
-- `verify_units=False` is removed. A whole-body exemption requires a structured
-  `ValidationExemption` and remains visibly unverified.
-- `cast_ttsim_unit` is deprecated. Dimensioned literals, alignment, semantic
-  reassignment, and last-resort type assertions use separate operations with structured
-  justification.
-- Existing functions, policy inputs, parameters, schedules, structured fields, rounding
-  rules, joins, hand-written aggregations, and generated nodes require complete resolved
-  value types before a policy package can claim conformance.
-- Naming suffixes remain mandatory where required by GEP 1, but they are consistency
-  checks and never the sole source of a value type.
-
-A project MAY stage migration behind a compatibility flag, but it MUST NOT describe a
-legacy adapter result as body-verified or fully typed unless every canonical axis has
-been resolved and validated.
+- Bare arrays and the DataFrame or mapping input interfaces remain supported.
+- `data_currency` defaults to `EUR`, so current-policy Euro input and output retain
+  their existing denomination.
+- The former `reference_period` and `reference_level` fields are replaced by the
+  compositional unit, for example `EUR_PER_YEAR_PER_FG`.
+- Existing policy functions, policy inputs, parameter files, hand-written aggregations,
+  and monetary rounding specifications require unit declarations.
+- `DIMENSIONLESS` remains the common unit for shares, rates without a period, IDs,
+  categories, and other physically dimensionless values. This GEP deliberately does not
+  introduce a public semantic-kind hierarchy.
+- `verify_units=False` remains available for one body, but every use is reported as an
+  unchecked body. It MUST NOT be counted as body verification.
+- `cast_ttsim_unit` remains available as a local assertion. Every use is reported
+  separately from inferred operations.
+- Unit validation cannot be disabled globally. `include_fail_nodes=False` may skip
+  selected fail nodes during environment assembly and annotated-input processing, but
+  malformed declarations remain errors.
 
 ## Detailed description
 
@@ -407,2275 +357,1095 @@ been resolved and validated.
 
 ### Design principles
 
-The implementation MUST follow these principles.
-
-1. **Independent facts use independent type axes.** A household is an entity domain, not
-   a physical denominator. A boolean is a semantic kind, not a dimensionless number.
-   February is a calendar ordinal, not an affine month point.
-1. **The canonical type is explicit.** Convenience constructors may fill documented
-   defaults, but every active leaf is resolved to a complete `ValueSpec` and every
-   compound producer to a complete `TypeSpec` before validation.
-1. **Operations are conservative.** An operation without a registered type rule fails.
-   It does not silently preserve the input type, discard an argument, or fall back to a
-   generic dimensionless result.
-1. **Scalar and vectorized code share one rule table.** Python operators, `xnp`
-   operations, and generated graph operations call the same type-rule implementation.
-1. **Relational transformations are explicit.** Broadcast, gather, join, aggregation,
-   deduplication, allocation, and per-capita transformations carry relation and
-   cardinality metadata.
-1. **Assertions are evidence, not verification.** A type assertion or whole-body
-   exemption is reported as such and cannot raise verified-body coverage.
-1. **All policy regimes are checked.** Validation uses the maximal date partition
-   induced by functions, parameters, schemas, units, currencies, rounding rules, and
-   generated nodes.
-1. **Registries are environment-local.** Currencies, entities, categories, keys,
-   primitive signatures, and period systems belong to an immutable `UnitSystem` or
-   policy environment. Process-global mutation is not part of the correctness contract.
-1. **Claims match evidence.** TTSIM may claim sound checking only for the documented
-   expression subset. Unsupported or exempt code remains visible in the evidence report.
-
-(gep-10-guarantee)=
-
-(gep-10-limitations)=
-
-### Validation guarantee and claim vocabulary
-
-For a node marked `BODY_VERIFIED`, the implementation guarantees the following,
-conditional on its stated trust boundary: if typed inputs satisfy their declared
-contracts, registered relations and primitive signatures are correct, and execution
-stays within the supported language, then every syntactic execution path is type safe
-under this GEP and every return is compatible with the declared result `TypeSpec`. “Type
-safe” means that no operation violates the physical, period, semantic-kind, subject,
-index, local-axis, extensity, calendar, currency, or nullability rules.
-
-This guarantee is deliberately conditional. It does not prove that:
-
-- the formula implements the statute or an economic model correctly;
-- an asserted relation is true of malformed runtime data unless its value constraints
-  are checked;
-- a result lies in an economically valid range;
-- floating-point evaluation is stable or finite;
-- an external primitive's implementation matches its registered signature; or
-- code outside the supported language has been analyzed.
-
-The public claim vocabulary is normative.
-
-| Claim                 | Minimum evidence                                                                                                                                                    |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type-resolved package | every active leaf and interval has a complete `ValueSpec`; no `UNRESOLVED_TYPE`                                                                                     |
-| body-verified package | every ordinary body is `BODY_VERIFIED`; every generated node is `DERIVED_BY_GENERATED_RULE`; trusted external primitives are enumerated                             |
-| boundary-verified run | the package is body verified and every supplied input leaf is independently typed and validated                                                                     |
-| GEP-10 fully verified | body-verified package, complete maximal date partition, no body exemptions, no `TYPE_ASSERTION_USED` qualifier, and a boundary-verified run for the claimed dataset |
-
-A package using untyped input may be body verified, but the run is not boundary
-verified. A package containing a reviewed body exemption may be type resolved, but it is
-not body verified or fully verified. User interfaces and release notes MUST use these
-terms or equally precise terms; they MUST NOT collapse them into “unit checked.”
+1. **Pint handles physical and reference-period algebra.** TTSIM does not replace Pint
+   with a general value-type system.
+1. **Grouping markers have a narrow purpose.** They catch selected group-total,
+   head-count, and group-indicator mistakes. They do not model arbitrary row grain.
+1. **Claims follow implementation.** A bounded placeholder evaluation is called a
+   linter, not a proof of arbitrary Python.
+1. **Supported operations inspect every unit-relevant operand.** A stand-in MUST NOT
+   discard a condition, fallback, key, period, or other operand and still count the body
+   as checked.
+1. **Unsupported grain-changing operations fail closed.** In-body reductions are not
+   assigned an unchanged unit when the checker lacks axis metadata.
+1. **Every distinct policy regime is checked.** Function boundaries alone are not an
+   exhaustive date partition; parameter and statutory-currency changes matter too.
+1. **Exceptions remain visible.** A declaration, cast, generated rule, checked body, and
+   whole-body opt-out are different facts and are reported separately.
+1. **One policy regime uses one statutory currency.** Mixed statutory currencies never
+   enter the same policy-function body.
 
 (gep-10-terminology)=
 
 ### Terminology
 
-| Term                  | Meaning                                                                                                                                                                                                        |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| physical unit         | Algebraic measure handled by Pint, such as currency, square meters, hectares, or working hours.                                                                                                                |
-| period specification  | Symbolic policy reference-period factor plus the convention and provenance governing conversion, such as a standard annualized month or an actual-day statutory rule. It is distinct from calendar duration.   |
-| semantic kind         | Meaning that is not captured by physical units, such as boolean, share, count, identifier, or category.                                                                                                        |
-| subject               | Entity the value describes, such as a person, household, or tax unit.                                                                                                                                          |
-| index                 | Relational row domain and representation on which a value is stored or evaluated.                                                                                                                              |
-| local axis            | Named non-row tensor dimension, such as choice, coefficient order, or stochastic node, with a typed coordinate and reduction contract.                                                                         |
-| extensity             | Whether values add over disjoint subject entities (`EXTENSIVE`), are pointwise nonadditive (`INTENSIVE`), are reducer-selected statistics (`STATISTIC`), or act as neutral constants or modifiers (`NEUTRAL`). |
-| relation              | Typed mapping between entity domains, including key domains and cardinality.                                                                                                                                   |
-| calendar point        | A coordinate on an affine calendar axis, such as a year or absolute date.                                                                                                                                      |
-| calendar ordinal      | A cyclic or contextual coordinate, such as month of year or day of month.                                                                                                                                      |
-| calendar duration     | A displacement on a calendar axis, such as years or days.                                                                                                                                                      |
-| statutory currency    | Concrete denomination in which the applicable law writes monetary parameters and coefficients.                                                                                                                 |
-| data currency         | Concrete denomination of user-provided monetary data or requested computed results.                                                                                                                            |
-| currency provenance   | Rule identifying where a denomination comes from and which effective date controls it.                                                                                                                         |
-| verification evidence | Machine-readable record of how a node's type was obtained and what was checked.                                                                                                                                |
-| assertion             | Explicit refinement of unresolved or deliberately broad type information that the checker cannot derive; it cannot overwrite a known conflicting type.                                                         |
-| exemption             | Structured decision not to body-check a function. Its declared result remains a consumer contract but is not verified.                                                                                         |
+| Term               | Meaning                                                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| quantity           | A value with a declared unit, such as income, age, a share, or a head count.                                                                           |
+| base               | The numerator of a compositional unit, such as `CURRENCY`, `DIMENSIONLESS`, or `YEARS`.                                                                |
+| period             | A denominator that distinguishes a flow or rate from a stock or bare quantity, such as `MONTH` or `YEAR`.                                              |
+| grouping level     | A restricted denominator identifying the group to which a measurable group quantity, count, or indicator belongs. It is not a complete row-grain type. |
+| bare               | A quantity without a grouping-level denominator. Personal quantities and physically dimensionless shares or rates are normally bare.                   |
+| stock              | A quantity without a period denominator, such as wealth.                                                                                               |
+| flow               | A quantity with a period denominator, such as income per month.                                                                                        |
+| rate               | A multiplicative quantity. A rate that turns a stock into a flow carries an inverse-period denominator.                                                |
+| calendar point     | A coordinate such as a calendar year.                                                                                                                  |
+| calendar ordinal   | A bounded coordinate within a wider context, such as month of year or day of month.                                                                    |
+| calendar duration  | A length such as years, months, or days.                                                                                                               |
+| statutory currency | The one concrete currency in which a policy regime's monetary parameters and rounding rules are written.                                               |
+| data currency      | The currency assumed for unannotated input and requested for computed output.                                                                          |
+| body check         | Bounded evaluation of a supported function body with unit-carrying placeholders.                                                                       |
+| cast               | A local assertion that replaces the inferred unit of one expression during body checking.                                                              |
+| opt-out            | `verify_units=False` on one body; its declaration remains a consumer contract, but the body is not checked.                                            |
 
 (gep-10-valuespec)=
 
 (gep-10-vocabulary)=
 
-### Canonical value type
+### Compositional unit vocabulary
 
-Every scalar or array leaf, parameter leaf, schedule coordinate, structured field,
-intermediate expression, generated leaf, and result leaf resolves to the following
-conceptual immutable type.
-
-```python
-@dataclass(frozen=True)
-class ValueSpec:
-    unit: PhysicalUnit
-    period: PeriodSpec
-    kind: SemanticKind
-    subject: SubjectSpec
-    extensity: Extensity
-    index: IndexSpec
-    axes: tuple[AxisSpec, ...]
-    calendar: CalendarSpec | None
-    currency: CurrencySpec
-    nullable: bool
-```
-
-The implementation may use different internal class names, but the fields and their
-semantics are normative. The resolved form MUST contain all fields. `None`, omitted
-fields, or legacy aliases may exist only before resolution, except that `calendar=None`
-is the resolved value for noncalendar kinds and `axes=()` is the resolved value for a
-leaf with no local tensor axes.
-
-Compound values use a structural type rather than pretending that a dictionary or
-callable has a physical unit.
-
-```python
-@dataclass(frozen=True)
-class StructSpec:
-    fields: Mapping[str, "TypeSpec"]
-
-
-@dataclass(frozen=True)
-class MappingSpec:
-    inputs: tuple[ValueSpec, ...]
-    output: "TypeSpec"
-
-
-TypeSpec = ValueSpec | StructSpec | MappingSpec
-```
-
-Every compound leaf is therefore checked, while the compound container itself has no
-fake unit, subject, or extensity. A value type is not a runtime wrapper around every JAX
-array. It is static graph metadata and an abstract-interpreter value. Typed input and
-output wrappers expose the same metadata at the boundary.
-
-(gep-10-hours)=
-
-#### Physical unit
-
-`PhysicalUnit` is a Pint unit expression over a policy-package registry. It contains
-only physical measures. The registry includes at least:
-
-- dimensionless one;
-- abstract currency;
-- area, including square meter and hectare;
-- working hours; and
-- additional package-defined physical measures.
-
-Entity domains, persons, groups, booleans, counts, identifiers, calendar points, and
-policy reference periods MUST NOT be Pint base dimensions.
-
-Concrete denominations such as EUR and DM are recorded in `CurrencySpec`; they are not
-separate physical dimensions. Both have physical unit `currency`.
-
-Examples:
-
-| Quantity                                        | `unit`                    | period signature |
-| ----------------------------------------------- | ------------------------- | ---------------- |
-| wealth                                          | `currency`                | `stock`          |
-| monthly income                                  | `currency`                | `per_month`      |
-| hourly wage                                     | `currency / work_hour`    | `stock`          |
-| weekly working hours                            | `work_hour`               | `per_week`       |
-| monthly rent per square meter                   | `currency / square_meter` | `per_month`      |
-| annual rate applied to a stock                  | `one`                     | `per_year`       |
-| Wohngeld coefficient multiplying monthly income | `1 / currency`            | `month`          |
-
-Pint supplies physical equivalence and physical conversion factors. It MUST NOT decide
-policy reference periods or conversion conventions, semantic kind, subject, row index,
-local tensor axes, extensity, calendar algebra, currency provenance, or nullability.
-
-(gep-10-periods)=
-
-#### Policy reference periods
-
-`PeriodSpec` contains a symbolic signature and a conversion convention.
-
-```python
-@dataclass(frozen=True)
-class PeriodSpec:
-    signature: PeriodSignature
-    convention: PeriodConvention
-```
-
-`PeriodSignature` is a multiplicative expression over one policy-reference-time
-dimension, with named units `YEAR`, `QUARTER`, `MONTH`, `WEEK`, and `DAY`. Its canonical
-exponents are signed integers. The named units are convertible under a registered
-convention; they are not independent dimensions. The signature is separate from physical
-time and from calendar duration.
+A unit consists of one base followed by at most one denominator from each supported
+category. Components have a fixed order.
 
 ```text
-stock       = 1
-per_month   = MONTH^-1
-per_year    = YEAR^-1
-month       = MONTH
-per_month_2 = MONTH^-2
+base        := CURRENCY
+             | EUR | DM
+             | DIMENSIONLESS
+             | HOURS
+             | SQUARE_METER | HECTARE
+             | YEARS | QUARTERS | MONTHS | DAYS
+             | CALENDAR_YEAR
+             | CALENDAR_QUARTER | CALENDAR_MONTH | CALENDAR_DAY
+
+physical    := SQUARE_METER | HOURS
+period      := MONTH | YEAR | QUARTER | WEEK | DAY
+level       := HH | BG | FG | SN | EG | EHE | WTHH | ...
+
+unit        := base
+             | base _PER_ physical
+             | base _PER_ period
+             | base _PER_ level
+             | base _PER_ physical _PER_ period
+             | base _PER_ physical _PER_ level
+             | base _PER_ period _PER_ level
+             | base _PER_ physical _PER_ period _PER_ level
 ```
 
-The general algebra is required because correct coefficients may carry a period in the
-numerator or higher powers. Public convenience constructors SHOULD cover common stock
-and flow cases.
+Each denominator category may appear at most once and must follow the order shown above.
+For example, `EUR_PER_MONTH_PER_YEAR` is invalid, as is `EUR_PER_BG_PER_MONTH`; use
+`EUR_PER_MONTH_PER_BG`.
 
-`PeriodConvention` identifies why a conversion factor is valid. Required forms are:
+In Python, declarations are constructed by chaining attributes:
 
-```text
-NONE
-STANDARD_ANNUALIZED[rule_id]
-CALENDAR_ACTUAL[rule_id]
-STATUTORY[rule_id]
-INHERITED[source_node]
+```python
+TTSIMUnit.CURRENCY.PER_MONTH.PER_BG
+TTSIMUnit.CURRENCY
+TTSIMUnit.DIMENSIONLESS
+TTSIMUnit.DIMENSIONLESS.PER_YEAR
+TTSIMUnit.HOURS.PER_WEEK
 ```
 
-Stocks use `NONE`. A standard annualized convention may define an exact context-free
-ratio such as 12 standard months per standard year. An actual-day or statutory proration
-rule may depend on a complete date interval, entitlement days, leap years, or another
-legal convention and therefore uses an explicit graph primitive rather than a
-context-free generated conversion.
+The YAML spelling joins the same components with `_PER_`.
 
-A policy package owns an immutable `PeriodSystem` containing named conventions, exact
-factors, valid source and target signatures, and provenance. A generated GEP 1
-conversion is permitted only when the source and target `PeriodSpec` are connected by a
-registered context-free rule. The conversion node records the rule identifier. It MUST
-NOT use a convenient fixed ratio for a quantity declared under an actual-calendar or
-statute-specific convention.
+#### Common declarations
 
-Multiplication and division combine period signatures algebraically and retain enough
-convention provenance to determine whether factors cancel. Convention compatibility is
-checked before period powers cancel; a standard monthly amount and an actual-day
-inverse-month coefficient do not become valid merely because their symbolic exponents
-sum to zero. When compatible period powers cancel to stock, the result convention is
-`NONE` and derivation evidence retains the source conventions. Addition, subtraction,
-branch unification, ordering, minimum, maximum, and clipping require equivalent
-signatures and compatible conventions after an explicitly permitted conversion.
+| Declaration                           | Resolved dimensionality       | Example                                             |
+| ------------------------------------- | ----------------------------- | --------------------------------------------------- |
+| `CURRENCY_PER_MONTH`                  | `CURRENCY / month`            | personal monthly income                             |
+| `CURRENCY_PER_MONTH_PER_BG`           | `CURRENCY / month / [bg]`     | monthly amount assigned to a Bedarfsgemeinschaft    |
+| `CURRENCY`                            | `CURRENCY`                    | wealth stock                                        |
+| `DIMENSIONLESS`                       | dimensionless                 | share, ID, category, or bare rate                   |
+| `DIMENSIONLESS_PER_YEAR`              | `1 / year`                    | linear annual rate applied to a stock               |
+| `DIMENSIONLESS_PER_BG`                | `1 / [bg]`                    | persons in, or indicator for, a Bedarfsgemeinschaft |
+| `HOURS_PER_WEEK`                      | `[hours] / week`              | weekly working hours                                |
+| `CURRENCY_PER_HOURS`                  | `CURRENCY / [hours]`          | hourly wage                                         |
+| `CURRENCY_PER_SQUARE_METER_PER_MONTH` | `CURRENCY / meter**2 / month` | monthly rent ceiling per square meter               |
+| `YEARS`                               | year duration                 | age or another duration in years                    |
+| `CALENDAR_YEAR`                       | calendar-year point           | birth year                                          |
+| `CALENDAR_MONTH`                      | month-of-year ordinal         | February represented as `2`                         |
 
-Let `P(source -> target)` be the exact numerical factor registered for one unit of the
-source period convention expressed in the target convention. For period exponent `e`,
-conversion multiplies the magnitude by `P(source -> target)^e`. This rule applies to
-inverse and higher-power coefficients as well as simple flows.
-
-The checker MUST reject a stock returned as a flow, even when both use currency. It MUST
-also reject an untyped coefficient whose missing inverse period happens to be
-numerically harmless in one currency regime.
+`CURRENCY` is an abstract code-side placeholder. TTSIM resolves it to the statutory
+currency for the policy date. Parameters, rounding specifications, and annotated input
+use concrete currencies where their denomination is fixed.
 
 (gep-10-kinds)=
 
-#### Semantic kinds
+#### Dimensionless semantic distinctions
 
-The minimum closed set of semantic kinds is:
+`DIMENSIONLESS` is deliberately not a semantic top type with a complete operation
+algebra. It is the physical unit shared by several meanings, including shares,
+identifiers, categories, indicators, counts, and bare rates. GEP 10 validates only the
+additional cases stated explicitly, such as truth compatibility and restricted
+group-level count or indicator declarations.
 
-```text
-NUMBER
-BOOLEAN
-SHARE
-PROBABILITY
-RATE
-COUNT[entity_domain]
-IDENTIFIER[key_domain]
-CATEGORY[category_domain]
-CALENDAR_POINT[axis]
-CALENDAR_DURATION[axis]
-CALENDAR_ORDINAL[axis]
-```
-
-Policy packages MAY register additional semantic kinds with explicit operation rules.
-They MUST NOT treat an unknown kind as `NUMBER` or `DIMENSIONLESS`.
-
-The built-in kinds have these meanings.
-
-- `NUMBER` is a numeric quantity whose physical unit and period carry its dimensional
-  content.
-- `BOOLEAN` is a truth value. It alone may appear in a truth context.
-- `SHARE` is a dimensionless multiplicative fraction. Optional boundary validation may
-  require it to lie in a declared range, commonly `[0, 1]`.
-- `PROBABILITY` is a dimensionless probability. It has stricter aggregation and range
-  semantics than a generic share.
-- `RATE` is a dimensionless or dimensioned multiplicative rate, possibly with a
-  non-stock period signature.
-- `COUNT[E]` records which entity domain is being counted. Count values are intended to
-  be integer-valued and nonnegative; that value constraint is checked at typed
-  boundaries and by generated count operations, rather than being inferred from storage
-  dtype. A count of persons is not a count of households.
-- `IDENTIFIER[K]` is a key in domain `K`. It supports equality, missingness, and
-  relational operations, not arithmetic.
-- `CATEGORY[C]` is a member of a declared finite or open category domain `C`. Categories
-  from different domains are incompatible.
-- Calendar kinds are defined in {ref}`Calendar types <gep-10-calendar>`.
-
-`BOOLEAN`, `IDENTIFIER`, `CATEGORY`, and `COUNT` are never inferred from a dimensionless
-Pint unit. They must be declared or derived by a typed operation. `COUNT[E]` supports
-equality, ordering, and addition or subtraction only with `COUNT[E]` at compatible
-subject and index. A package that requires subtraction to preserve nonnegativity
-attaches a value constraint or uses a registered `count_difference()` primitive. Counts
-do not enter unrestricted numeric arithmetic or stand in for shares, rates, or
-identifiers.
-
-The phrase **numeric kind** in this GEP means `NUMBER`, `SHARE`, `PROBABILITY`, `RATE`,
-or `COUNT[E]` only where the named operation has a rule for that kind. There is no
-implicit coercion from these kinds to `NUMBER`. In particular, physical
-dimensionlessness does not authorize arithmetic between a probability, count, and
-unrestricted number.
+A successful dimensional check therefore does not prove that an identifier was not
+multiplied by a share or that two dimensionless IDs belong to the same nominal domain.
+Adding those distinctions requires a separate semantic or relational type proposal.
 
 (gep-10-subject-index)=
 
 (gep-10-levels)=
 
-#### Subject and index
+### Grouping levels
 
-`subject` identifies the legal or statistical entity a value describes. `SubjectSpec`
-supports `GLOBAL`, one registered entity domain, or a registered composite subject.
-Built-in entity domains include `PERSON` and grouping domains such as `HH`, `BG`, `FG`,
-`SN`, `EG`, `EHE`, and `WTHH`.
+GETTSIM has a person level, identified by `p_id`, and grouping levels identified by
+`*_id` columns. Examples include households (`hh`), Familiengemeinschaften (`fg`),
+Bedarfsgemeinschaften (`bg`), tax units (`sn`), Einsatzgemeinschaften (`eg`),
+Ehegemeinschaften (`ehe`), and wohngeldrechtliche Teilhaushalte (`wthh`). See
+{ref}`GEP 2 <gep-2>`.
 
-`index` identifies where values are represented. It contains a relational row domain and
-a representation contract. The minimum representations are:
+A policy package registers its grouping levels with its unit system. Each level gains a
+`PER_<LEVEL>` builder step and a separate Pint base dimension. There is no person
+dimension: a person quantity is bare.
 
-```python
-Index.scalar()
-Index.unique(Entity.PERSON)
-Index.unique(Entity.HH)
-Index.broadcast(
-    source=Entity.HH,
-    rows=Entity.PERSON,
-    key=Key.HH_ID,
-)
-Index.gathered(
-    source=Entity.HH,
-    rows=Entity.PERSON,
-    key=Key.HH_ID,
-    cardinality=MANY_TO_ONE,
-)
-```
+#### What a group marker means
 
-A subject and an index answer different questions. A household amount repeated on every
-person row still has subject `HH`; its index records person rows and a certified
-household-key broadcast. This distinction lets the checker reject double-counting a
-repeated household value.
+A grouping-level denominator is permitted for a quantity that is both:
 
-Scalar policy parameters use `Index.scalar()` by default. A scalar may be broadcast to
-an array index when its subject and semantic role are compatible with the operation.
-Array-to-array pointwise operations require aligned row domains. Alignment across
-domains occurs only through a typed relation.
+1. a property calculated or assigned at the target group; and
+1. a measurable amount, count, or boolean indicator for which the supported group
+   arithmetic below is meaningful.
 
-The environment MUST know whether an array is unique at its logical source domain or
-repeated. It MUST NOT infer uniqueness merely from a suffix or from observed example
-values.
+Examples include monthly household rent, square meters per household, persons per
+household, and a household eligibility indicator.
 
-`axes` contains every non-row tensor dimension in storage order. Each `AxisSpec` has a
-nominal name, a coordinate `ValueSpec` or finite domain, an ordering contract, a
-broadcast rule, and the reducers permitted on that axis. Examples include `choice`,
-`stochastic_node`, `coefficient_order`, and `age_band`. Pointwise operations require
-identical local axes or a registered broadcast. Selecting, stacking, transposing, or
-reducing an axis produces a new explicit axis specification. A raw integer `axis=1` is
-resolved against this metadata; an untyped axis is rejected.
-
-The relational row index and local tensor axes are independent. A person-row array with
-a choice axis has a person `IndexSpec` and one `AxisSpec`; reducing choices does not
-aggregate persons, and aggregating persons does not silently reduce choices.
-
-Pointwise operations combine subjects and row indices by the following fail-closed rules
-after any explicit gather, broadcast, or scalar expansion has been represented in the
-graph.
-
-| Operands                                                                                                    | Result subject and row index                                                          |
-| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| same non-global subject, aligned row index                                                                  | preserve the common subject and aligned index                                         |
-| one `GLOBAL`, `NEUTRAL`, scalar operand                                                                     | preserve the other operand's subject and row index                                    |
-| one registered neutral or intensive modifier explicitly gathered or broadcast into the other operand's rows | preserve the modified operand's subject and row index; retain relation provenance     |
-| different extensive subjects                                                                                | error; use aggregation, allocation, reassignment, or another named semantic primitive |
-| different nonmodifier subjects                                                                              | error even when row lengths and dtypes happen to match                                |
-
-A scalar broadcast changes representation only. It never changes a non-global subject,
-key domain, or extensity. A relation-mediated broadcast can align rows without
-transferring ownership. The primitive's semantic signature decides whether a gathered
-value is a modifier, a comparison threshold, a selection condition, or an amount that
-still requires allocation.
-
-(gep-10-extensity)=
-
-#### Extensity
-
-`Extensity` has at least five values:
+The grouping marker is **not** attached merely because a value happens to be stored once
+per group. In particular, physically dimensionless shares and ordinary multiplicative
+rates remain bare:
 
 ```text
-EXTENSIVE
-INTENSIVE
-STATISTIC
-NEUTRAL
-NOT_APPLICABLE
+housing-cost share of a household     -> DIMENSIONLESS
+annual interest rate for a household  -> DIMENSIONLESS_PER_YEAR
+household identifier                  -> DIMENSIONLESS
 ```
 
-- `EXTENSIVE` values add over disjoint subject entities. Examples include personal
-  income, household rent totals, wealth, and working hours.
-- `INTENSIVE` values are pointwise quantities that do not add over disjoint entities.
-  Examples include shares, averages, wage rates, prices, and densities.
-- `STATISTIC` values are reducer-selected or order-dependent summaries at a target
-  subject, such as minima, maxima, quantiles, and a policy-defined first observation.
-  They are not totals and are not automatically pointwise modifiers. The derivation
-  evidence records the reducer.
-- `NEUTRAL` values are constants, thresholds, coefficients, or modifiers whose use may
-  preserve the extensity of another operand.
-- `NOT_APPLICABLE` is used for booleans, identifiers, categories, and calendar values.
+This GEP does not validate the row ownership or alignment of those bare values. That is
+a deliberate limitation rather than a claim that shares or rates lack a group-specific
+interpretation.
 
-For compatible numeric additions, extensity combines as follows. The table is symmetric
-in its left and right operands.
+Declaration validation MUST enforce this restriction. A direct
+`DIMENSIONLESS.PER_<LEVEL>` declaration is accepted only when the producer is known to
+be boolean or count-like from its Python return annotation or from a generated `COUNT`,
+boolean `SUM`, `ANY`, or `ALL` rule. A share, probability, or ordinary rate with a
+grouping marker is rejected regardless of storage dtype. When the available metadata
+cannot distinguish a count or indicator from another dimensionless value, validation
+fails conservatively rather than treating every dimensionless group value as admissible.
 
-| Left      | Right                  | Result                                            |
-| --------- | ---------------------- | ------------------------------------------------- |
-| extensive | extensive              | extensive, if subjects match                      |
-| extensive | neutral                | extensive, if subjects are compatible             |
-| intensive | intensive              | intensive, if subjects match                      |
-| intensive | neutral                | intensive, if subjects are compatible             |
-| statistic | statistic              | statistic, if subjects and indices match          |
-| statistic | neutral                | statistic, if subjects are compatible             |
-| neutral   | neutral                | neutral                                           |
-| extensive | intensive or statistic | error                                             |
-| intensive | statistic              | error unless a named primitive defines the result |
+#### Restricted group algebra
 
-A parameter threshold may be `NEUTRAL` while carrying subject `PERSON`; comparison or
-addition to a personal amount is then permitted without making the parameter aggregable.
-Aggregation rules use extensity explicitly and are defined separately.
+The checked group algebra is deliberately small.
 
-Generic numeric multiplication and division use the following default extensity rules
-after semantic-kind, subject, index, and local-axis compatibility has been established.
+1. A bare dimensionless scalar may multiply or divide a group quantity without changing
+   its group marker.
+1. Dividing a group total by a matching group head count cancels the group marker and
+   yields a bare per-person quantity.
+1. Multiplying a bare per-person quantity by a matching group head count acquires the
+   group marker and yields a group total.
+1. Logical operations may combine truth-compatible indicators under the rules in
+   {ref}`Booleans and truth contexts <gep-10-booleans>`. A known boolean indicator may
+   select or mask a same-level quantity through a conditional or `xnp.where`; the
+   condition does not multiply its grouping dimension into the selected value. Direct
+   multiplication may receive the same mask rule only when the producer is known to be
+   boolean.
+1. Generic multiplication or division of two other non-count quantities carrying
+   grouping markers is rejected. This prevents accidental squared grouping dimensions or
+   silent cancellation of two unrelated group properties.
+1. Generic multiplication or division of quantities carrying different grouping levels
+   is rejected.
 
-| Operation                                        | Default result                                                            |
-| ------------------------------------------------ | ------------------------------------------------------------------------- |
-| `NEUTRAL * X`, `X * NEUTRAL`, `X / NEUTRAL`      | extensity of `X`                                                          |
-| `EXTENSIVE * INTENSIVE`, `EXTENSIVE / INTENSIVE` | `EXTENSIVE` when the intensive operand is a registered pointwise modifier |
-| `INTENSIVE * INTENSIVE`, `INTENSIVE / INTENSIVE` | `INTENSIVE` only when the semantic-kind rule admits the operation         |
-| `STATISTIC * INTENSIVE`, `STATISTIC / INTENSIVE` | `STATISTIC` only when the intensive operand is a registered modifier      |
-| `STATISTIC * STATISTIC`, `STATISTIC / STATISTIC` | requires an explicit registered rule                                      |
-| `EXTENSIVE * EXTENSIVE`                          | error unless a named primitive defines the resulting meaning              |
-| `EXTENSIVE / EXTENSIVE`                          | requires a declared result kind and rule, commonly a share or rate        |
-| `NEUTRAL / X`                                    | requires an explicit registered rule                                      |
+The implementation MAY track “count-like” provenance internally for generated `COUNT`,
+boolean `SUM`, and explicitly declared head-count producers. This does not create a new
+public unit category.
 
-These defaults make wages times hours and prices per area times area extensive while
-rejecting a meaningless product of two totals. A primitive may define another result
-only with an explicit signature and tests.
-
-(gep-10-currency-type)=
-
-#### Currency specification and provenance
-
-`CurrencySpec` is required whenever the physical unit contains a nonzero power of
-currency. It has the conceptual forms:
+A head-count conversion is valid:
 
 ```text
-NONE
-STATUTORY(policy_date)
-CONCRETE(code, origin, stage)
-DATA(run_argument_or_column_tag)
-INHERITED(source_node, origin_date_rule)
-PRESENTATION(source_node, target_code, conversion_rule)
+wohnen__bruttokaltmiete_m_hh / anzahl_personen_hh
+  = (CURRENCY / month / [hh]) / (1 / [hh])
+  = CURRENCY / month
 ```
 
-`NONE` is required when the physical unit has no currency component. `STATUTORY` is used
-by currency-agnostic code-side declarations and resolves to a concrete denomination for
-a policy regime. Parameters, coefficients, rounding magnitudes, and typed input columns
-use a concrete currency or another explicit provenance rule.
+and so is the reverse:
 
-`origin` records enough information to answer why a denomination applies. At minimum it
-identifies one of:
-
-- the parameter effective date;
-- the current policy date;
-- the source data tag or `data_currency` assumption;
-- a carried value's originating policy period; or
-- an explicit conversion node and rate definition.
-
-A single ordinary numeric column MUST NOT contain row-wise mixed denominations. A
-package that needs mixed currencies must use a tagged union type and an explicit
-normalization operation; that extension is outside the required first implementation.
-
-Currency compatibility is checked independently of physical-unit equivalence. Two
-monetary values may both have physical unit `currency` and still be incompatible until a
-conversion node aligns their concrete denominations and provenance. Denominations are
-aligned before currency powers cancel: multiplying an EUR amount by a DM
-inverse-currency coefficient does not become valid merely because Pint would produce a
-dimensionless physical unit. After compatible currency factors cancel to exponent zero,
-the result has `CurrencySpec.NONE`, while derivation evidence retains the denominations
-and conversion rules used.
-
-(gep-10-nullability)=
-
-#### Nullability and typed missing values
-
-`nullable` records whether a value may be absent. Missingness is not represented by an
-arbitrary numeric sentinel.
-
-- An optional identifier has type `IDENTIFIER[K]` with `nullable=True`.
-- `MISSING_ID[K]` is a typed missing sentinel for identifier domain `K`.
-- `MISSING` in a branch or join fallback is a polymorphic missing literal that may unify
-  only with a nullable expected type.
-- A nonnullable value cannot receive `MISSING` through `where`, join fallback, lookup,
-  or branch unification.
-- `NaN` is a floating-point value and is not automatically a typed missing value.
-
-The input adapter MAY translate legacy sentinels such as `-1` to `MISSING_ID[K]`, but
-the mapping must be declared at the boundary and must not make equality between
-unrelated numeric and ID values legal inside policy code.
-
-Missing-value semantics are explicit.
-
-- Ordinary arithmetic and compatible comparisons propagate nullability: if any operand
-  may be missing, the result may be missing unless the primitive declares another
-  policy.
-- `is_missing(value)` and `is_not_missing(value)` return a nonnullable boolean at the
-  value's index and local axes. Source syntax `value == MISSING` and `value != MISSING`
-  MAY normalize to these primitives; no other equality with an untyped sentinel is
-  permitted.
-- A nullable boolean cannot control `if`, `where`, masking, `ANY`, or `ALL` until a
-  registered operation resolves missing conditions, for example
-  `fill_missing(condition, False)`.
-- `coalesce(value, fallback)` requires a fallback compatible with the nonnullable form
-  of the value and returns that nonnullable form.
-- Joins, schedules, reductions, and aggregations declare one of `ERROR`, `PROPAGATE`,
-  `SKIP`, or a reducer-specific missing policy. The default is `ERROR`, not
-  backend-dependent behavior.
-- Typed missingness is represented by masks or an equivalent backend-safe form. The
-  checker does not infer it from NaN payloads.
-
-(gep-10-declarations)=
-
-### Declaration syntax and resolution
-
-`ValueSpec` is the canonical leaf representation and `TypeSpec` is the canonical public
-type. Python convenience constructors under `Q` and structured YAML mappings are the
-public declaration syntaxes.
-
-#### Python constructors
-
-The required constructors include at least:
-
-```python
-Q.number(...)
-Q.money(...)
-Q.boolean(...)
-Q.share(...)
-Q.probability(...)
-Q.rate(...)
-Q.count(counted_entity, ...)
-Q.identifier(key_domain, ...)
-Q.category(category_domain, ...)
-Q.calendar_year_point(...)
-Q.date_point(...)
-Q.year_month_point(...)
-Q.calendar_duration(axis, ...)
-Q.month_of_year(...)
-Q.quarter_of_year(...)
-Q.day_of_month(...)
-Q.struct(fields={...})
-Q.mapping(inputs=(...), output=...)
+```text
+familie__anzahl_personen_sn * sparerfreibetrag_y
+  = (1 / [sn]) * (CURRENCY / year)
+  = CURRENCY / year / [sn]
 ```
 
-Constructors may provide only documented, type-safe defaults. For example, `Q.money()`
-may supply physical unit `currency`, kind `NUMBER`, and code-side currency `STATUTORY`;
-it may not infer subject or extensity from a name. `Q.identifier(Key.HH_ID)` supplies
-kind and key domain but not an unrelated grouping subject.
-
-#### YAML form
-
-The canonical YAML form is a mapping, not a composite string.
-
-```yaml
-value_type:
-  unit: currency
-  period:
-    signature: per_month
-    convention: gettsim_standard_annualized
-  kind: number
-  subject: person
-  extensity: extensive
-  index: person_unique
-  axes: []
-  calendar: null
-  currency:
-    denomination: EUR
-    provenance: source_column
-  nullable: false
-```
-
-Fields that are structurally fixed by the object MAY be omitted from source YAML but
-MUST appear in the resolved `ValueSpec`. For example, a scalar parameter has
-`index: scalar` and `axes: []`; a generated person-row input has an index supplied by
-its graph node. A compact `period: per_month` alias may expand to a package's explicitly
-named standard convention, but the canonical serialization contains both signature and
-convention. The evidence report records every field that was derived and the named rule
-that derived it.
-
-A compact alias MAY be supported if and only if it expands injectively to one canonical
-mapping. There must be one canonical serialization for equality, hashing, diagnostics,
-and evidence.
-
-#### Declaration matrix
-
-| Object                        | Required declaration                        | Additional validation                                                      |
-| ----------------------------- | ------------------------------------------- | -------------------------------------------------------------------------- |
-| `@policy_function`            | `value_type=`                               | body, return, suffix, subject, index, local axes, exceptions               |
-| `@policy_input`               | `value_type=`                               | suffix, subject, index, local axes, boundary compatibility                 |
-| scalar parameter              | `value_type:`                               | dated resolution, concrete currency, leaf shape                            |
-| dictionary parameter          | one type or per-leaf types                  | complete leaf coverage per regime                                          |
-| mapping or schedule parameter | typed input axes and output                 | arity, domain kinds, output suffix                                         |
-| structured parameter function | `Q.struct(fields=...)`                      | field access and source-to-field mapping                                   |
-| generated period conversion   | derived `ValueSpec`                         | only period specification, magnitude, and conversion provenance may change |
-| generated aggregation         | derived `ValueSpec`                         | relation, uniqueness, extensity, result subject                            |
-| join or gather node           | derived `ValueSpec`                         | key domains, cardinality, fallback, row domains                            |
-| hand-written aggregation      | result `value_type=` plus relation metadata | exact agreement with derived rule or assertion                             |
-| group-creation function       | identifier or relation type                 | key domain, uniqueness, membership                                         |
-| rounding specification        | concrete typed magnitudes                   | function type, denomination, effective date                                |
-| typed input column            | complete source `ValueSpec`                 | target compatibility and conversion                                        |
-
-A missing declaration is an error unless a unique normative generated rule supplies it.
-An opaque `UNSET_UNIT` does not satisfy this requirement. Structured values use a
-structured type.
-
-#### Suffix validation
-
-GEP 1 time and grouping suffixes remain useful redundant checks.
-
-- A `_m`, `_y`, `_q`, `_w`, or `_d` suffix must agree with the result's simple flow
-  period when the name denotes a flow.
-- A group suffix must agree with the declared subject where GEP 1 defines that suffix as
-  the subject of the result.
-- An identifier suffix determines a candidate key domain but does not turn a number into
-  an ID.
-- Suffixes do not describe period conventions, extensity, semantic kind, row
-  representation, local tensor axes, join cardinality, calendar semantics, currency
-  provenance, or nullability.
-- A name and declaration disagreement is always an error; neither takes precedence.
-
-(gep-10-rules)=
-
-### Expression type rules
-
-The type checker operates on resolved `ValueSpec` objects. The following rules are
-normative. An implementation may use more detailed internal types but may not accept an
-expression rejected by these rules without an explicit assertion or exemption.
-
-#### Equivalence, compatibility, and conversion
-
-Two value types are **equivalent** when all canonical axes are equal after resolving
-aliases and concrete policy-date metadata. Two value types are **compatible** for a
-named operation when the operation's rule explicitly permits a conversion, scalar
-broadcast, neutral modifier, nullable unification, or relation-mediated alignment.
-
-Physical, period, and currency conversion MUST be explicit in the typed graph, even when
-generated automatically from naming conventions. The abstract interpreter may insert a
-generated conversion node only where the graph builder would insert the same numerical
-conversion and provenance at runtime.
-
-A type comparison MUST NOT reduce to Pint dimensionality alone.
-
-#### Addition and subtraction
-
-Numeric addition and subtraction require:
-
-- compatible semantic kinds;
-- physically equivalent units;
-- equivalent period signatures and compatible conventions after an allowed conversion;
-- compatible currency denomination and provenance;
-- aligned indices and local axes, allowing registered scalar or axis broadcast;
-- compatible subjects; and
-- a valid extensity combination.
-
-The result preserves the common unit, period specification, kind, subject, index, local
-axes, calendar state, and currency; result nullability is the union of operand
-nullability unless a registered missing-value rule resolves it. Extensity is combined by
-the table above.
-
-Identifiers, categories, booleans, and calendar ordinals do not support ordinary numeric
-addition or subtraction. Counts use the same-counted-entity rule above and do not mix
-with unrestricted numbers. Calendar points and durations use their separate affine
-rules.
-
-A subtraction of two compatible extensive amounts remains extensive. A subtraction of
-two calendar points returns a calendar duration. These are different rules and cannot be
-selected from dtype alone.
-
-#### Multiplication and division
-
-Multiplication and division combine physical units and period signatures algebraically
-and carry period-convention provenance through the registered rule. The operation must
-also have a registered semantic, subject, index, local-axis, and extensity rule.
-
-The required built-in rules include:
-
-- `NUMBER × NUMBER` and `NUMBER / NUMBER`, producing `NUMBER` with algebraically
-  combined unit and period;
-- an extensive or intensive numeric quantity multiplied or divided by a `SHARE`,
-  `PROBABILITY`, `RATE`, or neutral coefficient, preserving the quantity's subject and
-  extensity unless the rate's declared semantics specify another result;
-- a neutral coefficient with inverse unit or period multiplying a quantity, with the
-  resulting physical unit, period signature, and convention cancellation checked
-  normally;
-- a typed group-mean, allocation, or count-scaling rule involving `COUNT[E]` and a
-  declared relation; and
-- division of like numeric quantities producing a dimensionless `NUMBER`, `SHARE`, or
-  `RATE` only when the result kind is declared or uniquely implied by the registered
-  primitive.
-
-Plain multiplication by a count does not silently change a person amount into a
-household total. The checker requires `total_from_mean()`, `allocate_equal()`, or
-another registered equivalent carrying the relation and intended result subject.
-Similarly, plain division by a head count does not silently erase or change a group
-subject; `mean_per_member()` and `allocate_equal()` encode the two distinct meanings.
-
-The checker rejects semantic products for which no rule exists, even if the physical
-Pint expression is valid.
-
-#### Ordering comparisons
-
-`<`, `<=`, `>`, and `>=` require comparable numeric or calendar types. Numeric operands
-must have compatible unit, period specification, denomination, subject, extensity role,
-index, and local axes. A scalar neutral threshold may compare with a compatible indexed
-quantity.
-
-The result is `BOOLEAN` at the aligned row index. Its subject is the subject of the
-indexed quantity or the common subject when both are indexed.
-
-Counts may be ordered only against the same `COUNT[E]` kind or a typed count literal.
-Identifiers and categories are not ordered unless their nominal domain explicitly
-registers an ordering. An ID is not ordered merely because its storage dtype is integer.
-
-#### Equality and inequality
-
-Equality is checked; it is not a blanket exemption.
-
-`==` and `!=` are permitted only for:
-
-- equivalent or operation-compatible numeric types;
-- booleans;
-- identifiers in the same key domain;
-- an optional identifier and `MISSING_ID` of the same key domain;
-- categories in the same category domain;
-- compatible calendar values of the same calendar kind and axis; and
-- a nullable value and the typed `MISSING` sentinel, normalized to `is_missing` or
-  `is_not_missing`.
-
-The following are errors:
-
-```python
-monthly_income == annual_income
-hh_id == bg_id
-p_id == -1
-month_of_year == benefit_share
-category_a == category_from_another_domain
-```
-
-Legacy ID sentinel comparisons must be normalized at the input boundary or use a typed
-helper such as `is_missing(id_value)`.
+A policy interpretation that transfers an amount from one group concept to another must
+use a local cast or an explicitly declared aggregation. The unit system does not infer
+membership relations between `[hh]`, `[bg]`, `[eg]`, and other levels.
 
 (gep-10-booleans)=
 
-#### Boolean operations and truth contexts
+### Booleans and truth contexts
 
-Only nonnullable `BOOLEAN` may be consumed by a truth or logical operation unless the
-primitive has an explicit missing-condition policy.
+The public unit vocabulary does not distinguish every semantic kind of dimensionless
+value. The unit checker therefore establishes **truth compatibility**, not full Boolean
+semantics.
 
-Python `if`, conditional expressions, `and`, `or`, `not`, and `assert` require a scalar
-boolean: `Index.scalar()` and no non-singleton local axis. A boolean array in a Python
-scalar truth context is rejected even though its semantic kind is correct. Loops are
-outside the initial supported language.
+A unit-carrying value is truth-compatible only if it has no physical or period dimension
+and carries at most one permitted grouping-level marker. Python annotations and runtime
+type validation remain responsible for distinguishing actual booleans from IDs, counts,
+shares, and other dimensionless values.
 
-`xnp.where`, `xnp.select`, `xnp.logical_*`, `&`, `|`, `^`, and `~` accept scalar or
-array booleans according to their registered broadcast and alignment rules. Numeric
-bitwise operations are outside the default policy-expression subset. `ANY` and `ALL`
-consume boolean values through typed reduction rules. Direct boolean indexing or masking
-is unsupported unless a registered primitive defines the resulting index, local axes,
-and shape contract.
+The following contexts MUST apply the same truth-compatibility check:
 
-All non-scalar boolean operands must have aligned row indices and local axes. A group
-boolean gathered to person rows may combine with a person boolean because the relation
-has made the row alignment explicit. The result is a person-row boolean; the gathered
-value's provenance remains available in the expression evidence.
+- Python `if` and conditional expressions;
+- `bool(value)` as invoked by branch exploration;
+- `not`, `&`, `|`, `^`, and `~` where supported; and
+- the `condition` argument of `xnp.where`.
 
-The scalar and vectorized implementations MUST call the same rule. In particular,
-`xnp.where` MUST validate its condition before unifying its result arms.
-
-#### Conditional expressions and branch joins
-
-For `x if condition else y`, `xnp.where(condition, x, y)`, and every other selection
-primitive:
-
-1. `condition` must be boolean and nonnullable, or the selection primitive must declare
-   how a missing condition is resolved;
-1. both result arms are analyzed;
-1. the arms must be equivalent or unify through the typed-zero, typed-missing,
-   scalar-broadcast, or explicitly registered numeric-conversion rules; and
-1. the result is the least type admitted by that rule, including nullability.
-
-The checker must analyze both branches syntactically. It must not depend on a
-placeholder's chosen runtime truth value to discover one branch.
-
-(gep-10-literals)=
-
-#### Numerical literals
-
-`True` and `False` are nonnullable `BOOLEAN` literals with global subject, scalar index,
-no local axes, `NOT_APPLICABLE` extensity, and no currency. They may broadcast only
-through a registered boolean or selection primitive.
-
-A nonzero numeric literal has type `NUMBER`, physical unit one, stock period, global
-subject, neutral extensity, scalar index, and no currency. It cannot be added to,
-ordered against, or used as a branch replacement for a dimensioned value without an
-explicit typed literal.
+A currency stock, age, annual rate, or monthly amount cannot control a branch:
 
 ```python
-income_m < quantity_literal(
-    1000.0,
-    value_type=Q.money(
-        period=Period.per_month(),
-        subject=Entity.PERSON,
-        extensity=Extensity.NEUTRAL,
-    ),
-    assertion=AssertionRef("GEP10-LITERAL-001"),
-)
+@policy_function(unit=TTSIMUnit.CURRENCY)
+def invalid(wealth: float) -> float:
+    return wealth if wealth else 0.0
 ```
 
-Statutory constants SHOULD be parameters rather than implementation literals.
+`xnp.where` MUST check its condition before unifying the two result arms. Refactoring a
+scalar conditional into a vectorized conditional must not remove a unit check.
 
-Literal zero is represented internally as `ZERO_LITERAL`. It may adopt an expected
-numeric type only in these contexts:
+Logical operators preserve a common grouping level when both operands have that level.
+When one operand is bare and one carries a grouping level, or when the levels differ,
+the result is bare because the operation is evaluated row-wise. This rule is a pragmatic
+unit rule and is not a general proof of row alignment.
 
-- additive identity;
-- a conditional or `where` arm;
-- a `min`, `max`, or `clip` bound;
-- a numeric comparison; or
-- a return with a declared numeric expected type.
+Ordering comparisons require unit-compatible operands and produce a truth-compatible
+result. Equality remains unit-blind; see
+{ref}`Trade-offs and limitations <gep-10-limitations>`.
 
-Zero cannot adopt `BOOLEAN`, `IDENTIFIER`, `CATEGORY`, or a calendar-point type. `False`
-is a boolean literal, not a numeric zero. A nonzero ID sentinel is never a
-dimensioned-literal exception.
+(gep-10-hours)=
 
-Literal one has a narrower contextual rule. `ONE_LITERAL` may adopt `SHARE` or
-`PROBABILITY` only in a registered complement or unit-interval-bound context, such as
-`1 - probability` or `share <= 1`. It cannot adopt a count, identifier, category,
-dimensioned number, calendar value, or arbitrary rate. Other nonzero share, probability,
-rate, or count constants use typed literals. The evidence and diagnostics record every
-contextual zero or one adoption.
+### Physical and calendar dimensions
 
-Category, identifier, count, and calendar constants use nominal typed constructors or
-registered enum objects:
+#### Working hours
 
-```python
-category_literal("single", domain=MARITAL_STATUS)
-identifier_literal(17, domain=Key.HH_ID)
-count_literal(2, counted_entity=Entity.PERSON, subject=Entity.HH)
-month_of_year_literal(2)
-```
+Working hours use a dedicated `[hours]` dimension rather than Pint's calendar-time
+dimension. Otherwise, hours per week would reduce to a dimensionless ratio and could not
+be distinguished from a share.
 
-Raw strings and integers do not acquire these kinds from the other operand of an
-equality test. Legacy encodings are decoded at a typed boundary.
-
-#### Minimum, maximum, clipping, and rounding
-
-`min`, `max`, `clip`, `xnp.minimum`, `xnp.maximum`, and their registered variants
-require compatible numeric operands and preserve the unified value type. They do not
-change subject or extensity. A typed zero bound is permitted.
-
-Numerical `round` preserves the value type. Statutory rounding is a graph operation with
-a typed `RoundingSpec` and currency rules defined below.
-
-#### Powers and transcendental functions
-
-Integer powers combine physical and period exponents algebraically. A noninteger power
-requires a resulting physical unit whose exponents remain representable and
-policy-approved, and it is permitted only when the policy reference period remains
-stock. Noninteger powers of currency or a policy reference period are rejected by the
-standard registry; a specialized primitive must normalize those dimensions before
-returning a boundary-convertible value.
-
-`exp`, `log`, and trigonometric functions require dimensionless `NUMBER` inputs with a
-stock period and compatible semantic role. They do not accept shares, probabilities,
-IDs, counts, or calendar values merely because those are physically dimensionless. A
-package may register a specialized transformation with an explicit signature.
+`HOURS_PER_WEEK` therefore resolves to `[hours] / [time]`.
 
 (gep-10-calendar)=
 
-### Calendar types
+#### Calendar points, durations, and ordinals
 
-Calendar semantics are separate from physical units and policy reference periods. Every
-calendar value has `unit=one`, `period=stock`, `currency=NONE`, and
-`extensity=NOT_APPLICABLE`. Its calendar semantic kind is paired with a non-null
-`CalendarSpec`:
+`CALENDAR_YEAR` is an affine point on the calendar-year axis. `YEARS` is a duration.
+Their supported algebra is:
 
-```python
-@dataclass(frozen=True)
-class CalendarSpec:
-    axis: CalendarAxis
-    system: CalendarSystem
-    arithmetic_rule: CalendarArithmeticRule | None
-    domain: CalendarDomain
-```
+| Operation                      | Result                 | Example                       |
+| ------------------------------ | ---------------------- | ----------------------------- |
+| point minus point              | duration               | `policy_year - geburtsjahr`   |
+| point plus or minus duration   | point                  | `geburtsjahr + statutory_age` |
+| ordering of two points         | truth-compatible value | `geburtsjahr <= policy_year`  |
+| point plus point               | error                  | adding two birth years        |
+| point times scalar             | error                  | scaling a birth year          |
+| point ordered against duration | error                  | comparing birth year with age |
 
-`axis` identifies `YEAR`, `YEAR_MONTH`, `DATE`, a duration axis, or an ordinal domain.
-`system` identifies the civil-calendar system, normally the proleptic Gregorian calendar
-for GETTSIM. `arithmetic_rule` names any normalization or end-of-month rule required by
-an admitted operation. `domain` records finite ordinal bounds or the representable point
-domain. The axis encoded in the calendar semantic kind MUST equal `CalendarSpec.axis`.
-Noncalendar kinds require `calendar=None`.
+Quarter of year, month of year, and day of month are **ordinals**, not context-free
+affine points. `2 CALENDAR_MONTH` means February and `15 CALENDAR_DAY` means the
+fifteenth day within a wider date context. These declaration tokens are nominal ordinal
+markers whose allowed operations are supplied by TTSIM's validator rules; they are not
+ordinary Pint affine-point units. They support equality and ordering within the same
+ordinal axis, but they do not support generic point-plus-duration or point-minus-point
+algebra.
 
-The required calendar types are:
-
-```text
-CALENDAR_POINT[YEAR]
-CALENDAR_POINT[YEAR_MONTH]
-CALENDAR_POINT[DATE]
-CALENDAR_DURATION[YEAR]
-CALENDAR_DURATION[MONTH]
-CALENDAR_DURATION[DAY]
-CALENDAR_ORDINAL[QUARTER_OF_YEAR]
-CALENDAR_ORDINAL[MONTH_OF_YEAR]
-CALENDAR_ORDINAL[DAY_OF_MONTH]
-```
-
-A policy package may add compatible axes. The following distinctions are mandatory.
-
-- `1999` as a year point is affine on the year axis.
-- `(1999, 2)` as a year-month point is affine under explicit month arithmetic.
-- an absolute date is a complete date point.
-- `2` as month of year means February and is a cyclic ordinal, not a point.
-- `15` as day of month is a contextual ordinal, not a point.
-- age in years is a year duration, not a year point and not a policy annual flow period.
-
-#### Supported affine algebra
-
-| Operation                           | Result           | Requirement                               |
-| ----------------------------------- | ---------------- | ----------------------------------------- |
-| year point − year point             | year duration    | same axis and calendar convention         |
-| year point ± year duration          | year point       | same axis                                 |
-| year-month point − year-month point | month duration   | same axis and normalization convention    |
-| year-month point ± month duration   | year-month point | explicit normalized year-month arithmetic |
-| date point − date point             | day duration     | same calendar system                      |
-| date point ± day duration           | date point       | calendar-aware date operation             |
-| date point ± month or year duration | date point       | explicit end-of-month convention          |
-| point ordered against point         | boolean          | same point axis                           |
-| duration ± duration                 | duration         | same duration axis                        |
-| point + point                       | error            | points are affine, not vectors            |
-| point × number                      | error            | no point scaling                          |
-| point ordered against duration      | error            | incompatible calendar kinds               |
-
-Month-of-year, quarter-of-year, and day-of-month ordinals support equality and ordering
-within the same ordinal domain. They do not support point-plus-duration arithmetic or
-subtraction yielding a duration. `December + 2 months` is therefore invalid until
-December is paired with a year to form a year-month point and a wrap convention is
-explicit.
-
-Boundary validation MUST enforce integer or registered-enum representation, `1..4` for
-quarter of year, `1..12` for month of year, and `1..31` for day of month. Fractional
-ordinals are invalid. Actual day validity, including leap-day validity, requires a
-complete date.
-
-`policy_year` is a year point. `policy_month` is a month-of-year ordinal. `policy_day`
-is a day-of-month ordinal. `policy_date` is an absolute date point. The same rules apply
-to evaluation date components.
-
-Flow conversion between monthly and annual amounts is unrelated to calendar-point
-arithmetic. The implementation MUST use distinct classes and rule paths for these
-concepts.
-
-(gep-10-relations)=
-
-### Keys, relations, joins, and alignment
-
-A `RelationSpec` describes a mapping between entity domains. It contains at least:
-
-```python
-@dataclass(frozen=True)
-class RelationSpec:
-    source: EntityDomain
-    target: EntityDomain
-    foreign_key: KeyDomain
-    primary_key: KeyDomain
-    cardinality: Cardinality
-    missing_policy: MissingPolicy
-    uniqueness: UniquenessContract
-```
-
-Key domains are nominal. Equal storage dtype or equal numerical values do not make two
-key domains compatible.
-
-#### Gather and join
-
-A typed gather has the conceptual signature:
+In particular, the unit system does not define:
 
 ```text
-gather(
-    foreign_key: Series[Identifier[K]?, source_rows],
-    primary_key: Series[Identifier[K], target_rows],
-    target: Series[T, target_rows],
-    cardinality: MANY_TO_ONE,
-    on_missing: MissingPolicy[T],
-) -> Series[T, source_rows]
+December + 2 months
+31st day + 1 day
+February 29 without a year and calendar
 ```
 
-Validation requires:
+Framework-provided `policy_quarter`, `policy_month`, and `policy_day` values MAY remain
+represented as dimensionless ordinals. This GEP does not claim to validate their
+complete calendar semantics. A future calendar proposal may add explicit range and
+context rules without changing the physical-unit model adopted here.
 
-- equal key domain `K` on foreign and primary keys;
-- nonnullable and unique primary keys;
-- a declared cardinality compatible with the operation;
-- source and target row domains matching the relation;
-- an `on_missing` value that is exactly compatible with `T`, or typed `MISSING` when the
-  resulting gather is nullable;
-- no numeric or category key masquerading as an identifier; and
-- no silent subject reassignment.
-
-The output preserves the target's physical unit, period specification, kind, subject,
-extensity, local axes, calendar, and currency semantics while changing its index to the
-source rows and recording gathered provenance. Its nullability is the union of target
-nullability and the declared missing policy. A later operation may use it as a modifier
-or explicitly reassign or allocate its subject under a policy rule.
-
-One-to-many and many-to-many joins require separate primitives with result-shape
-semantics. They must not be accepted by a many-to-one stand-in.
-
-#### Broadcast and scalar expansion
-
-Scalar expansion is permitted when a scalar's subject and semantic role are compatible
-with the receiving operation. A group-to-person broadcast requires a relation and a
-uniqueness contract. The result index records that values repeat by the declared key.
-
-A repeated value cannot be aggregated over the finer row domain as if every row were an
-independent source value. The checker requires deduplication or aggregation at the
-logical source domain.
-
-#### Subject reassignment and allocation
-
-Some laws deliberately move or allocate an amount between legal entities. This is not a
-unit conversion. It uses a named semantic operation such as:
-
-```python
-reassign_subject(
-    value,
-    to=Entity.BG,
-    relation=EG_TO_BG,
-    assertion=AssertionRef("SGBXII-TO-SGBII-001"),
-)
-```
-
-or an allocation operation that declares weights and conservation rules. These
-operations retain physical unit, period specification, local axes, and currency type but
-change subject and evidence. A generic full-type cast is not the normal interface for
-cross-level policy semantics.
-
-(gep-10-aggregations)=
-
-### Aggregations and reductions
-
-An aggregation is typed by the source value, source index, source uniqueness, relation,
-reducer, target entity and target universe, any weights or ordering, an explicit
-missing-value policy, and an explicit empty-group policy. Physical units alone are
-insufficient. The default missing policy is `ERROR`; `SKIP` changes the effective
-denominator and must be part of the reducer signature and evidence.
-
-Missing source values and empty target groups are different cases. `EmptyGroupPolicy` is
-one of `ERROR`, `MISSING`, or a reducer-specific typed identity. The standard identities
-are typed zero for `SUM` and `COUNT`, `False` for `ANY`, and `True` for `ALL`; a package
-may instead choose `ERROR` or `MISSING`. `MEAN`, `WEIGHTED_MEAN`, `MIN`, `MAX`, `FIRST`,
-and `UNIQUE` have no default identity. A nullable or identity-producing result is
-derived from the declared policy; backend accident is never the source of empty-group
-semantics.
-
-#### Required aggregation rules
-
-| Aggregation                       | Input requirement                                                                             | Result                                                                        |
-| --------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `SUM`                             | extensive numeric value, unique at source entities                                            | same unit and period; extensive; subject and unique index become target       |
-| `SUM` over boolean                | boolean unique at source entities                                                             | `COUNT[source_entity]`; subject and index target                              |
-| `MEAN`                            | numeric value unique at source entities                                                       | same unit and period; intensive statistic; subject and index target           |
-| `WEIGHTED_MEAN`                   | numeric values plus aligned dimensionless weights, normalization rule, and zero-weight policy | same unit and period; intensive statistic; subject and index target           |
-| `MIN`, `MAX` over numeric values  | ordered numeric values                                                                        | same unit, period, and kind; `STATISTIC`; subject and index target            |
-| `MIN`, `MAX` over calendar values | one compatible calendar kind and axis                                                         | same calendar semantics; `NOT_APPLICABLE` extensity; subject and index target |
-| `COUNT`                           | rows or values unique at a declared counted entity                                            | `COUNT[counted_entity]`; subject and index target                             |
-| `ANY`, `ALL`                      | boolean values                                                                                | boolean; subject and index target                                             |
-| `UNIQUE`                          | certified constant or repeated value per target                                               | de-duplicated value at target; otherwise error                                |
-| `FIRST`                           | explicit deterministic ordering and policy meaning                                            | same unit, period, and kind; `STATISTIC` at target plus ordering evidence     |
-
-A mean of person wealth by kinstead is currency-valued, intensive, and has subject
-kinstead. It is not physically `currency / kinstead`, and it is not a person-level
-value.
-
-Weighted means require weights aligned to the source row index and relevant local axes.
-The weight kind is `SHARE` or a registered dimensionless weighting kind; standard
-weights are nonnegative, and a currency amount or count cannot be used as a weight. The
-primitive declares whether it normalizes raw weights, requires them to sum to one, and
-what happens when the total weight is zero. A signed-weight estimator requires a
-separately named primitive. These value constraints are checked where runtime values are
-available and recorded separately from static type evidence.
-
-A sum over a repeated household total on person rows is rejected because the input is
-not unique at the source entities. `UNIQUE` or a group-indexed source must be used
-first.
-
-A hand-written aggregation must provide the same relation metadata and must declare a
-result type that exactly matches the derived rule. A different intended meaning uses a
-named assertion or semantic transformation, not `verify_units=False`.
-
-#### Per-member statistics, allocation, and count scaling
-
-Division by a head count has two common meanings and therefore uses two different
-primitives.
-
-`mean_per_member(total, count, relation)` requires an extensive total whose subject is
-the relation target, a `COUNT[source_entity]` at the same target, and a nonzero-count
-policy. It returns an `INTENSIVE` statistic with the same target subject and target
-index. The value describes the average per source member, but it remains one group-level
-statistic. Broadcasting it to source rows does not change that subject.
-
-`allocate_equal(total, count, relation)` has the same input requirements but returns an
-`EXTENSIVE` amount with source-entity subject and a source-row index. It records an
-equal-allocation and conservation contract: summing the nonmissing allocations through
-the same relation must recover the input total, subject to the declared zero-count and
-numerical-rounding policy. Weighted allocation uses
-`allocate(total, weights, relation, conservation=...)`; weights must be aligned,
-dimensionless shares and their normalization rule must be explicit.
-
-`total_from_mean(mean, count, relation)` may reconstruct an extensive target total from
-a target intensive per-member statistic. `sum_allocations(allocation, relation)`
-aggregates source allocations normally. No generic division or multiplication by a count
-changes subject by itself.
-
-#### In-body array reductions
-
-`xnp.sum`, `xnp.mean`, `xnp.min`, `xnp.max`, and similar reductions MUST inspect
-array-axis metadata. A reduction axis is either:
-
-- a local tensor axis with a declared semantic axis and a registered reduction rule; or
-- a row/entity axis, in which case a `RelationSpec` and target are required.
-
-A `where` mask on a reduction must be a nonnullable boolean aligned with the reduced
-value after registered broadcasting. It is an inclusion mask, not an implicit
-missing-value policy. A reduction that removes an axis removes its `AxisSpec`;
-`keepdims=True` retains a declared singleton form of that axis. The result index and
-remaining local-axis order are derived rather than copied from the input.
-
-A stand-in that discards `axis`, `where`, `keepdims`, weights, initial value, or
-row-domain information is nonconforming. If an axis has no static metadata, the
-reduction is rejected. Contributors may move the operation into a generated typed
-aggregation or register a precise local-tensor signature.
-
-(gep-10-schedules)=
+Reference-period conversion for flows is separate from calendar arithmetic. Converting
+`CURRENCY_PER_YEAR` to `CURRENCY_PER_MONTH` is not calendar-point addition.
 
 (gep-10-parameters)=
 
-### Parameters, schedules, and structured values
+### Parameter declarations
 
-#### Dated scalar and dictionary parameters
+Units are declared at parameter definition. Declaration shape follows parameter shape.
 
-A scalar parameter declares one `ValueSpec`. A homogeneous dictionary may share one
-type; a heterogeneous dictionary declares a complete type mapping over the union of leaf
-paths that can exist in any date regime.
+#### Scalars and dictionaries
 
-Dated declarations use forward fill only where explicitly specified. A dated type
-mapping replaces the prior mapping as a complete mapping unless the schema explicitly
-defines fieldwise inheritance. The value-merging rule and type-inheritance rule are
-separate.
+A scalar parameter and a dictionary with homogeneous leaves use one unit declaration.
 
-At each validated date regime:
+```yaml
+satz:
+  unit: EUR_PER_MONTH
+  type: scalar
+  2023-01-01:
+    value: 250.0
+  2024-01-01:
+    note: Depends on the number of children since 2024.
 
-- every resolved leaf has one type;
-- no absent leaf is spuriously required;
-- no present leaf is untyped;
-- concrete monetary types match the applicable statutory denomination and provenance
-  rule; and
-- a value change cannot silently retain an incompatible old type.
-
-#### Mapping and schedule parameters
-
-A mapping parameter uses a typed function signature.
-
-```python
-Q.mapping(
-    inputs=(
-        Q.category(DISABILITY_DEGREE),
-        Q.count(Entity.PERSON, subject=Entity.HH),
-    ),
-    output=Q.money(
-        period=Period.per_year(),
-        subject=Entity.HH,
-        extensity=Extensity.NEUTRAL,
-        currency="EUR",
-    ),
-)
+satz_nach_kindanzahl:
+  unit: EUR_PER_MONTH
+  type: dict
+  2024-01-01:
+    1: 250.0
+    2: 250.0
 ```
 
-The number and order of input axes must match every lookup call. Each axis carries the
-complete kind, unit, period, calendar, nominal-domain, ordering, and nullability
-semantics needed for lookup or interpolation. Output suffix checks apply to the output
-type only.
+A dictionary with heterogeneous leaves uses a mapping from leaf keys to units.
 
-Categorical and identifier axes permit exact lookup only. Numeric or calendar axes
-permit interpolation only through a registered method whose signature defines coordinate
-conversion, boundary inclusion, extrapolation, missing values, and result type. A
-schedule wrapper must forward all coordinates and options; discarding a secondary axis,
-interpolation mode, or fallback is a validation failure.
+```yaml
+schedule:
+  unit:
+    child_amount_y: EUR_PER_YEAR
+    max_age: YEARS
+  type: dict
+  2024-01-01:
+    child_amount_y: 3000.0
+    max_age: 18
+```
 
-Piecewise-polynomial coefficients declare the mathematically implied unit and period for
-each order. For input type `X` and output type `Y`, an order-`j` coefficient has numeric
-unit and period `Y / X^j`, with compatible semantic and currency provenance. The
-implementation must not label all coefficients dimensionless and rely on
-statutory-currency execution to hide the omission.
+The unit mapping is the union of leaves that can occur over the parameter's date range.
+At one policy date, validation requires declarations only for leaves present in the
+resolved value.
 
-#### Parameter functions and structures
+A dated entry may replace or introduce a unit declaration. The most recent declaration
+at or before the policy date applies. A dated per-leaf mapping replaces the previous
+mapping completely and declares every leaf present at that date.
 
-A structured parameter function returns `Q.struct(fields=...)`, with a value type for
-every accessible leaf or nested object. `UNSET_UNIT` is not a type. A converter may
-rename, combine, or derive fields, but its body or a registered transformation signature
-must explain the output field types.
+(gep-10-schedules)=
 
-A source-to-field comparison is made whenever lineage is known. Renamed or derived
-fields do not become unchecked merely because paths differ; the converter's typed body
-or explicit field mapping supplies the evidence.
+#### Mapping parameters
 
-Schedule-producing parameter functions declare the complete typed input and output
-signature. Every lookup, interpolation, and polynomial evaluation is validated at the
-call site and in the producer.
+A schedule or lookup table declares input and output axes rather than one scalar unit.
+
+```yaml
+freibetrag_bei_behinderung_gestaffelt_y:
+  input_unit: DIMENSIONLESS
+  output_unit: EUR_PER_YEAR
+  type: piecewise_constant
+  # Intervals omitted.
+```
+
+The parameter schema rejects `unit:` on a mapping type that requires `input_unit:` and
+`output_unit:`. A time suffix in the parameter name describes the output axis and must
+agree with `output_unit`.
+
+#### Parameter functions
+
+A `@param_function` converts a raw YAML parameter declared with
+`type: require_converter` into the object used by policy functions. Its unit declaration
+describes the converted result.
+
+Schedule-producing parameter functions declare input and output units:
+
+```python
+@param_function(
+    unit=InputOutputUnits(
+        input_unit=TTSIMUnit.CURRENCY.PER_YEAR,
+        output_unit=TTSIMUnit.CURRENCY.PER_YEAR,
+    ),
+)
+def tarif() -> PiecewisePolynomialParamValue: ...
+```
+
+Every supported `look_up` or `piecewise_polynomial` call screens its domain argument
+against the declared input axis and yields the declared output unit.
+
+Structured parameters may declare `unit=UNSET_UNIT` only when their result has no single
+unit and every unit-carrying field has its own annotation.
+
+```python
+@dataclass(frozen=True)
+class SatzMitAltersgrenzen:
+    satz: Annotated[float, TTSIMUnit.CURRENCY.PER_MONTH]
+    altersgrenzen: Altersgrenzen
+    nach_anzahl_kinder: Annotated[
+        ConsecutiveIntLookupTableParamValue,
+        InputOutputUnits(
+            input_unit=TTSIMUnit.DIMENSIONLESS,
+            output_unit=TTSIMUnit.CURRENCY.PER_MONTH,
+        ),
+    ]
+
+
+@param_function(unit=UNSET_UNIT)
+def satz_mit_altersgrenzen() -> SatzMitAltersgrenzen: ...
+```
+
+When a policy function accesses an annotated scalar field, body checking uses the
+field's unit. If a YAML leaf path matches an annotated field path, validation compares
+the two declarations. Renamed or derived fields have no automatic source-path
+comparison.
 
 (gep-10-generated)=
 
 (gep-10-auto)=
 
-### Generated nodes
+### Generated nodes and aggregations
 
 #### Reference-period conversions
 
-A generated period conversion changes only:
+A generated reference-period conversion changes only the period component of a unit. For
+example, converting a household amount from monthly to yearly changes
+`CURRENCY_PER_MONTH_PER_HH` to `CURRENCY_PER_YEAR_PER_HH`; currency, physical
+components, and grouping level remain unchanged.
 
-- the period signature or convention admitted by the named conversion rule;
-- the numerical magnitude by the exact factor and exponent rule in `PeriodSystem`; and
-- period-conversion provenance.
+Pint supplies the ordinary ratios used by the existing generated converters. These are
+conventions for linear flows. They do not establish that every statute uses the same
+day-count or partial-period rule, and they do not convert effective returns by
+compounding.
 
-It preserves semantic kind, subject, extensity, index, local axes, calendar state,
-currency denomination, currency provenance, and nullability. It may also update a name
-suffix according to GEP 1.
+The treatment of daily and other legally sensitive period conventions is deferred to
+[GETTSIM #1205](https://github.com/ttsim-dev/gettsim/issues/1205). Until that work is
+completed:
 
-If a coefficient carries a period in the numerator or a higher power, conversion applies
-algebraically. The system must not assume that every monetary value is a simple flow
-with exponent `-1`. A date-dependent proration is a named calendar/statutory primitive,
-not this generated context-free conversion.
+- generated conversions retain the factors currently used on `main`;
+- the checker establishes dimensional compatibility, not statutory day-count
+  correctness; and
+- a formula requiring a different convention uses an explicit policy function rather
+  than an automatic suffix conversion.
 
-#### Generated grouping nodes
+(gep-10-extensity)=
 
-Generated aggregates, joins, group IDs, broadcasts, and per-capita nodes use the
-relational rules above. They do not synthesize Pint group dimensions.
+(gep-10-aggregations)=
 
-A generated group identifier has kind `IDENTIFIER[group_key_domain]`, not `NUMBER` or
-`DIMENSIONLESS`. A generated membership relation declares source, target, keys,
-cardinality, and missing policy.
+#### Aggregations
 
-#### Generated currency nodes
+Generated aggregations derive their result unit from the source unit, aggregation type,
+and target level.
 
-Currency conversion is represented as an explicit typed boundary or graph node. It
-changes the magnitude, concrete denomination, and provenance record while preserving
-semantic kind, subject, extensity, index, local axes, calendar semantics, and
-nullability. It preserves the physical currency exponent and period specification.
+| Aggregation            | Base                             | Result level                               |
+| ---------------------- | -------------------------------- | ------------------------------------------ |
+| `SUM` of a non-boolean | preserved                        | target group; bare at an individual target |
+| `MIN`, `MAX`, `MEAN`   | preserved                        | target group; bare at an individual target |
+| `COUNT`                | `DIMENSIONLESS`                  | target group; bare at an individual target |
+| `SUM` of a boolean     | `DIMENSIONLESS` count            | target group; bare at an individual target |
+| `ANY`, `ALL`           | truth-compatible `DIMENSIONLESS` | target group; bare at an individual target |
 
-Let `C(source -> target)` denote the exact number of target-currency units equal to one
-source-currency unit. If the physical unit contains currency with signed-integer
-exponent `k`, conversion multiplies the magnitude by `C(source -> target) ** k`. This
-covers inverse-currency coefficients and higher powers; a converter that always
-multiplies by the first-power rate is nonconforming. The standard currency boundary
-rejects noninteger currency exponents.
+A mean is a statistic of the target group. It does **not** become a person-level value
+merely because a symbolic group total divided by a head count would cancel the grouping
+denominator. Thus the mean wealth of a household has a household result level. To create
+a person-level allocation or per-person amount, use an explicit group-total/head-count
+calculation or an aggregation whose declared target is the individual person.
 
-(gep-10-currency)=
+`MIN` and `MAX` likewise remain properties of the target group. The current unit system
+does not distinguish totals, means, and extrema beyond the aggregation rule that
+produced them; it only checks their base, period, and target level.
 
-### Currency and statutory computation
+A hand-written aggregation declares its unit. That declaration MUST exactly match the
+unit derived from its source, aggregation type, and target level. An intentional policy
+reinterpretation uses a local cast or `verify_units=False`, both of which are reported.
 
-#### Environment-local currency system
+`@agg_by_p_id_function` assigns each result to an individual person and therefore has no
+grouping-level denominator. A group identifier remains `DIMENSIONLESS` because nominal
+identifier domains are outside this GEP.
 
-Each policy package constructs one immutable `UnitSystem`. Its currency component
-contains:
+(gep-10-relations)=
 
-- a currency family identifier;
-- a closed set of concrete denominations;
-- one exact conversion graph within the family;
-- statutory-effective-date history;
-- conversion-rate provenance; and
-- a policy for carried or retroactive amounts whose denomination is controlled by an
-  origin date other than the current policy date.
+#### Joins
+
+The body checker provides only a dimensional join guard. For a supported `join` call:
+
+- modeled foreign and primary keys MUST carry no physical or period dimension;
+- the missing-key fallback MUST be unit-compatible with the target, except for the
+  documented dimensionless sentinel case; and
+- the result inherits the target unit.
+
+This check does **not** establish that the two keys have the same nominal domain, that
+the primary key is unique, that cardinality is correct, or that source and destination
+rows are aligned. Those properties remain the responsibility of the existing relation
+and runtime validation layers.
+
+A join stand-in that ignores a key or fallback is nonconforming. If a future join option
+has unit-relevant behavior and no unit rule, the call must be rejected rather than
+silently returning the target unit.
+
+#### In-body reductions
+
+Raw array reductions such as `xnp.sum`, `xnp.amin`, and `xnp.amax` can change which rows
+or axes a result represents. The current unit checker has no static array-axis metadata
+from which to derive that change. It therefore MUST reject these operations during body
+checking instead of passing through the operand's unit.
+
+A function requiring such a reduction must either:
+
+- express it as a generated or hand-written aggregation with a declared target level; or
+- use `verify_units=False`, which is then reported as an unchecked body.
+
+This conservative refusal closes a false-certification path; it is not a claim that all
+reductions are dimensionally invalid.
+
+(gep-10-declarations)=
+
+### Declaration rules
+
+#### Declaration matrix
+
+| Object                               | Declaration                           | Currency base                      | Validation                                               |
+| ------------------------------------ | ------------------------------------- | ---------------------------------- | -------------------------------------------------------- |
+| `@policy_function`                   | required `unit=`                      | `CURRENCY` for monetary values     | declaration, suffixes, and supported body paths          |
+| `@policy_input`                      | required `unit=`                      | `CURRENCY` for monetary values     | declaration and suffixes                                 |
+| scalar or dictionary parameter       | `unit:`                               | concrete currency where monetary   | schema, suffix, and statutory currency                   |
+| mapping parameter                    | `input_unit:` and `output_unit:`      | concrete currency where applicable | schema and axes                                          |
+| structured `@param_function`         | `unit=UNSET_UNIT`                     | units on fields                    | field use and matching parameter leaves                  |
+| schedule-producing `@param_function` | `InputOutputUnits(...)`               | abstract `CURRENCY` in code        | schedule call sites                                      |
+| generated time conversion            | automatic                             | inherited                          | target period from suffix                                |
+| generated aggregation                | automatic                             | inherited                          | aggregation rule and target level                        |
+| hand-written aggregation             | required `unit=`                      | abstract `CURRENCY` in code        | exact derived unit unless opted out                      |
+| group-creation function              | required or generated `DIMENSIONLESS` | not applicable                     | declaration only                                         |
+| rounding specification               | required for monetary magnitudes      | concrete currency                  | function unit and statutory currency                     |
+| unit-annotated input                 | required on every leaf in that mode   | concrete source currency           | token vocabulary, suffix period, and currency conversion |
+
+Use `UNSET_UNIT` only for a structured producer with no single unit. For ordinary
+parameters, functions, and aggregations, a missing declaration is an error.
+
+(gep-10-literals)=
+
+### Numerical literals
+
+Multiplication and division by a bare numerical literal are valid and preserve or
+compose the other operand's unit.
 
 ```python
-from fractions import Fraction
+betrag_m * 0.5  # CURRENCY_PER_MONTH
+wealth * 0.8  # CURRENCY, not CURRENCY_PER_MONTH
+```
 
-UNIT_SYSTEM = UnitSystem(
-    currency_family=CurrencyFamily(
-        base="EUR",
-        to_base={
-            "EUR": Fraction(1, 1),
-            "DM": Fraction(100_000, 195_583),  # one DM in EUR
-        },
-        statutory_intervals=(
-            CurrencyInterval("1948-06-20", "2001-12-31", "DM"),
-            CurrencyInterval("2002-01-01", None, "EUR"),
-        ),
-        provenance="legally fixed EUR/DM conversion",
-    ),
-    period_system=GETTSIM_PERIOD_SYSTEM,
-    entities=GETTSIM_ENTITIES,
-    key_domains=GETTSIM_KEYS,
+A non-zero bare literal cannot be added to, subtracted from, or ordered against a
+dimensioned quantity.
+
+```python
+einkommen_m < 1000.0  # Invalid: different units.
+```
+
+A dimensioned threshold should normally be a parameter. If it must remain in the body, a
+local cast gives the literal its intended unit.
+
+```python
+einkommen_m < cast_ttsim_unit(
+    value=1000.0,
+    unit=TTSIMUnit.CURRENCY.PER_MONTH,
 )
 ```
 
-The ordering of mapping entries is not the semantic source of truth. The constructor
-validates a well-founded conversion graph, one base per family, unique names under case
-normalization, and no collision with declaration syntax.
+Zero is the sole polymorphic numerical-literal exception. It may act as an additive
+identity, return arm, or `min`/`max`/`clip` bound and adopts the compatible other unit.
 
-A `UnitSystem` is passed explicitly or owned by a policy environment. Registering a
-second policy package in the same process cannot mutate the first package's type
-vocabulary or conversion behavior.
+```python
+@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+def betrag_m(einkommen_m: float, befreit: bool) -> float:
+    return 0.0 if befreit else einkommen_m
+```
 
-#### Statutory denomination
+A bare literal cannot acquire an identifier, category, or calendar-point meaning through
+this rule. Those distinctions are outside the unit system and remain subject to ordinary
+runtime typing and policy review.
 
-For a policy-date regime, code-side `STATUTORY` monetary types resolve to the concrete
-denomination in which the applicable law writes its parameters and coefficients. A
-monetary parameter or coefficient declares a concrete currency and origin. The
-environment rejects a declaration that is incompatible with its statutory-effective-date
-rule unless the parameter explicitly declares another legally meaningful provenance,
-such as a carried amount from an earlier period.
+(gep-10-nullability)=
 
-Parameters and coefficients retain their written numerical values. They are not
-mechanically rewritten into the caller's data currency. This preserves legally rounded
-changeover amounts and currency-dependent formula coefficients.
+### Missing values and nullability
 
-The type checker still requires complete units for coefficients. Statutory evaluation
-guarantees a consistent denomination; it does not convert a mathematically
-inverse-currency coefficient into a dimensionless number.
+Missingness is not a physical unit. This GEP does not replace GEP 9's runtime treatment
+of nullable values, sentinels, or backend-specific missing representations. During body
+linting, a missing-key fallback is checked only for dimensional compatibility with the
+join target. The unit checker does not prove that a numeric sentinel is valid for a
+particular identifier domain.
 
-#### Carried, retroactive, and mixed-origin amounts
+A `NaN`, `-1`, or other sentinel does not acquire semantic missing-value meaning from
+`DIMENSIONLESS`. Policy packages remain responsible for their ordinary runtime and data
+validation contracts.
 
-A value whose denomination is determined by an origin or entitlement period rather than
-the current policy date uses `INHERITED(source_node, origin_date_rule)` or another
-explicit provenance rule. The environment must resolve whether conversion occurs when
-the value is created, carried, combined, or paid.
+(gep-10-currency-type)=
 
-The current policy date MUST NOT silently relabel a carried DM amount as EUR. Combining
-amounts with different concrete denominations requires an explicit conversion node and
-rate provenance.
+(gep-10-currency)=
 
-Retroactive calculations must state whether statutory rounding occurs in the
-origin-period currency before conversion or in a payment-period currency after
-conversion. The default is no implicit conversion and therefore a validation error until
-the rule is explicit.
+### Currency
 
-#### Boundary conversion order
+#### Registration and statutory currency
 
-For ordinary GETTSIM runs, the normative order is:
+A policy package constructs one `UnitSystem` containing its supported currencies and
+statutory history. GETTSIM uses Euro as the base currency and defines Deutsche Mark by
+the official conversion factor.
 
-1. validate or assume the input `ValueSpec`;
-1. convert monetary input to the denomination required at its first policy boundary;
-1. perform policy arithmetic using statutory parameters and fully typed coefficients;
-1. apply each statutory rounding rule in its declared concrete denomination at its
-   declared graph location;
-1. complete all statutory calculations and retain the canonical statutory result; and
-1. derive a requested data-currency presentation view through an explicit output
-   conversion.
+```python
+UNIT_SYSTEM = UnitSystem(
+    currencies={
+        "EUR": Currency(statutory_from="2002-01-01"),
+        "DM": Currency(
+            value="EUR / 1.95583",
+            statutory_from="1948-06-20",
+        ),
+    },
+)
+```
 
-The presentation view has `PRESENTATION(...)` provenance and records whether the source
-value had already undergone statutory rounding. It is not relabeled as a legally rounded
-amount in the presentation currency. Typed output can expose both the canonical
-statutory result and the presentation view. Presentation rounding after output
-conversion is nonstatutory and must use a distinct option and evidence record.
+Exactly one currency is statutory at every supported policy date. That currency is the
+**only** denomination permitted inside the active policy computation.
 
-#### Numerical representation at the boundary
+Environment assembly MUST verify that, for every checked regime:
 
-Currency rates are stored as exact rationals or exact decimal specifications with source
-and legal provenance. Numerical conversion applies the exponent rule above and has the
-following dtype contract.
+- every active concrete monetary parameter uses the statutory currency;
+- every active monetary rounding specification uses the statutory currency;
+- every code-side `CURRENCY` declaration resolves to the statutory currency; and
+- no active producer introduces a second concrete currency into a policy-function body.
 
-- Nullable arrays preserve their missing-value mask and convert only present values.
-- Floating-point arrays preserve their floating dtype unless an explicit output-dtype
-  policy says otherwise. The exact factor is rounded once to that dtype under the
-  backend's documented rounding mode. A finite input whose exact converted value is
-  outside the finite range raises `CurrencyConversionOverflow`; finite input must not
-  silently become infinity or NaN.
-- Integer monetary data must either promote to a declared noninteger type or prove exact
-  divisibility for every present value; silent truncation is forbidden.
-- Decimal or exact-rational values use a compatible exact conversion path or fail
-  explicitly.
-- Complex monetary values are rejected.
-- Object arrays are rejected unless one registered converter handles every present
-  element and publishes its result dtype.
-- Existing NaN and infinities are not unit errors. A separate data-validity option may
-  reject or preserve them, and the evidence report must distinguish that policy from
-  type validation.
-- Underflow and backend rounding of finite floating values follow the declared dtype
-  semantics and are covered by numerical conformance tests; the evidence records backend
-  and dtype.
-- Currency conversion must not alter identifiers, categories, booleans, counts, or
-  nonmonetary quantities.
+The single-currency invariant deliberately excludes simultaneous DM and EUR values from
+one policy regime. Retroactive or carried amounts that must retain a different legal
+denomination require a future extension and are not silently admitted by this GEP.
 
-NumPy and JAX front ends must use the same exact registry rate, exponent, promotion
-policy, and operation order. Bitwise equality across backends is not promised where
-their documented floating-point semantics differ, but each result must satisfy the
-package's stated dtype-level numerical tolerance and all no-truncation,
-no-silent-overflow, and rounding-order requirements.
+#### Parameters and data currencies
+
+Parameters are not converted. Validation instead requires their concrete currency to
+match the statutory currency of every regime in which they are active. This preserves
+statutory numerical values, including legally rounded values introduced at a currency
+changeover.
+
+Input data may use a different concrete currency. Monetary inputs are converted to the
+statutory currency before policy evaluation. Computed monetary outputs are converted to
+`data_currency` only after statutory calculation and rounding.
+
+An annotated input may therefore contain DM values for a Euro policy run or Euro values
+for a DM policy run. The boundary performs the conversion before the values enter the
+DAG. Mixed source currencies across separately annotated input leaves are acceptable
+only because each leaf is converted to the one statutory currency before policy
+computation.
+
+#### Currency changes in parameter histories
+
+A dated parameter entry inherits the most recent earlier unit declaration. A new unit
+declaration applies from its date onward.
+
+```yaml
+arbeitnehmerpauschbetrag_y:
+  type: scalar
+  1990-01-01:
+    unit: DM_PER_YEAR
+    value: 2000
+  2002-01-01:
+    unit: EUR_PER_YEAR
+    value: 1044
+  2011-01-01:
+    value: 1000
+```
+
+Resolution uses only declarations at or before the policy date. A statutory-currency
+transition opens a new validation regime even when no function starts or ends on that
+date.
+
+#### Coefficients whose numerical meaning depends on currency
+
+Some statutory formulas contain coefficients whose mathematical units include inverse
+currency, even when the statute prints them as bare numbers. The present compositional
+vocabulary does not attempt to encode arbitrary inverse-currency powers for all
+structured coefficients.
+
+The adopted first-stage rule is therefore:
+
+- evaluate the complete formula in the one statutory currency of the regime;
+- retain the statutory coefficient values exactly as written; and
+- do not claim that the unit checker has proved the dimensional semantics of
+  coefficients represented as bare values.
+
+Such formulas may require a local cast or body opt-out and appear as such in the
+validation report. Statutory-currency evaluation preserves their numerical convention;
+it is not a substitute for full coefficient-unit verification.
 
 (gep-10-rounding)=
 
-### Rounding specifications
+#### Rounding specifications
 
-A statutory `RoundingSpec` declares typed magnitudes, concrete denomination,
-effective-date range, and legal reference.
+A monetary rounding specification declares the concrete currency and complete unit of
+its numerical magnitudes.
 
 ```python
 @policy_function(
-    value_type=Q.money(
-        period=Period.per_year(),
-        subject=Entity.SN,
-        extensity=Extensity.EXTENSIVE,
-    ),
+    end_date="2001-12-31",
+    leaf_name="zu_versteuerndes_einkommen_y_sn",
     rounding_spec=RoundingSpec(
         base=54,
         direction="down",
         to_add_after_rounding=27,
-        value_type=Q.money(
-            period=Period.per_year(),
-            subject=Entity.SN,
-            extensity=Extensity.NEUTRAL,
-            currency="DM",
-        ),
         reference="§ 32a Abs. 2 EStG",
+        unit=TTSIMUnit.DM.PER_YEAR.PER_SN,
     ),
-    end_date="2001-12-31",
+    unit=TTSIMUnit.CURRENCY.PER_YEAR.PER_SN,
 )
-def zu_versteuerndes_einkommen_y_sn() -> float: ...
+def zu_versteuerndes_einkommen_y_sn(): ...
 ```
 
-The rounding magnitude's physical unit, period specification, subject compatibility, and
-concrete denomination must match the value being rounded after resolving `STATUTORY`. A
-function active across a statutory-currency or rounding-rule change must have dated
-rounding regimes or split definitions.
-
-The maximal date partition includes every rounding start, end, and rule change. A
-rounding rule cannot be inherited across a denomination change by accident.
+The rounding unit must equal the function unit after resolving `CURRENCY` to the
+statutory currency. A function active across a statutory-currency change must be split
+or receive date-appropriate rounding specifications. Presentation-currency conversion
+occurs after rounding.
 
 (gep-10-validation)=
 
 (gep-10-checks)=
 
-### Validation architecture
+### Validation and limitations
 
-Validation has seven distinct stages. Implementations may combine passes internally, but
-evidence must preserve the distinction.
+#### Validation stages
 
-| Stage                            | Validates                                                                  |
-| -------------------------------- | -------------------------------------------------------------------------- |
-| declaration parsing              | syntax, required fields, closed enums, registry membership                 |
-| canonical resolution             | complete `ValueSpec`, defaults, aliases, currency and date resolution      |
-| graph validation                 | edge compatibility, generated conversions, relations, joins, aggregations  |
-| body abstract interpretation     | supported expressions, branches, calls, returns, assertions                |
-| regime validation                | maximal policy-date partition and all active declarations in each interval |
-| input/output boundary validation | source tags, dtypes, ranges when requested, conversion                     |
-| evidence and release gate        | statuses, coverage, exceptions, expiry, conformance suite                  |
+| Stage                         | When                            | Input                                  | Validates                                                                            |
+| ----------------------------- | ------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------ |
+| declaration validation        | decoration or parameter loading | declarations                           | required fields, grammar, suffixes, and allowed currency bases                       |
+| environment validation        | policy-environment assembly     | graph declarations and generated rules | required units, aggregation derivations, statutory currency, and regime completeness |
+| function-body linting         | policy-environment assembly     | unit-carrying placeholders             | supported operations and explored returns                                            |
+| annotated-input boundary      | input canonicalisation          | user tags and column names             | known tokens, exact suffix period, and source-currency conversion                    |
+| numerical boundary conversion | before and after computation    | values and conversion factor           | input to statutory currency; computed results to data currency                       |
 
-Passing declaration parsing does not imply that a body was checked. Passing body
-validation at one date does not imply that all parameter or currency regimes were
-checked.
+Pint quantities are used while declarations and policy environments are checked, while
+annotated input is processed, and while numerical conversion factors are derived. Pint
+quantities do not enter the compiled tax-and-transfer function or a JAX trace.
 
 (gep-10-body-checker)=
 
-### Function-body abstract interpretation
+#### Function-body linting
 
-#### Supported-language contract
+TTSIM evaluates a policy-function body with placeholders carrying the declared units of
+its arguments. Conditional branches are explored by re-evaluating the body with
+different branch decisions. Each explored return path is checked separately.
 
-TTSIM validates policy bodies by parsing the supported Python subset into a typed
-intermediate representation and interpreting that representation over abstract
-`ValueSpec` values. It does not claim that arbitrary placeholder execution proves a
-function correct.
+The body checker is a linter over a documented operation set. It is conforming only when
+every supported stand-in inspects every operand that can affect the result's unit.
+Scalar and vectorized spellings of the same operation MUST use equivalent rules.
 
-The supported subset includes, at minimum:
+Body linting rejects, among other things:
 
-- local assignments and returns;
-- arithmetic and comparison operators with registered rules;
-- boolean operators, scalar truth contexts, and `assert` statements;
-- conditional statements and conditional expressions;
-- attribute and field access on typed structures;
-- typed indexing, slicing, stacking, and selection with registered index and local-axis
-  rules;
-- calls to typed policy functions, parameter functions, schedules, and registered
-  primitives;
-- scalar and vectorized `xnp` operations with registered signatures; and
-- explicit assertion and semantic-conversion primitives.
+- addition, subtraction, or ordering of unit-incompatible quantities;
+- a non-zero bare literal used as a dimensioned value;
+- a return unit that differs from the declaration in physical dimension, period, or
+  grouping level;
+- a value with physical or period content used in a truth context;
+- an `xnp.where` condition with physical or period content;
+- unsupported in-body reductions;
+- a supported join with a physically dimensioned key or incompatible fallback;
+- an untyped numerical value accessed from a structured parameter;
+- inconsistent schedule input and output axes; and
+- any operation for which no faithful unit stand-in exists, unless the function
+  explicitly opts out.
 
-Loops, comprehensions, dynamic dispatch, reflection, mutation, exception-driven control
-flow, or calls whose target cannot be resolved are unsupported until a sound rule is
-registered.
+The checker MUST NOT silently preserve the input unit when an operation changes a
+unit-relevant axis or grouping interpretation. A stand-in that discards `axis`,
+`condition`, `foreign_key`, `primary_key`, `fallback`, or another unit-relevant argument
+is nonconforming.
 
-Unsupported syntax is a validation failure with status `UNSUPPORTED_BODY`. It must not
-be executed with a permissive stand-in that guesses a result type.
-
-#### Syntax-directed branch analysis
-
-The checker analyzes every syntactic branch and joins branch result types. It does not
-choose a truth value for an abstract operand to discover one path at a time.
-Consequently, a function with `n` independent conditions does not require enumerating
-`2^n` placeholder executions merely to check branch return types.
-
-Where value-dependent refinement is needed, the checker may refine nullability, category
-variants, or other finite type facts. Such refinement must be conservative and
-documented. Failure to prove a refinement rejects the dependent operation rather than
-assuming it.
-
-A resource limit may protect the checker from pathological source. Crossing it produces
-a visible `CHECKER_RESOURCE_LIMIT` failure. It does not turn the body into a verified
-declaration.
-
-#### One primitive registry
-
-All operations are registered in one immutable primitive-signature registry owned by the
-`UnitSystem`. Scalar, vectorized, and generated front ends lower to the same primitive.
-
-Each registry entry declares every public alias, complete argument roles, result rule,
-supported index and local-axis broadcasts, value constraints, backend availability, and
-conformance tests. The implementation generates a public operation inventory from this
-registry. A scalar or vectorized alias without an entry, or an entry without required
-mutation and parity tests, fails the release gate.
-
-Examples:
-
-```text
-Python ternary     ─┐
-xnp.where          ├─> SELECT(condition, true_value, false_value)
-xnp.select         ┘
-
-Python sum         ─┐
-xnp.sum            ├─> REDUCE_SUM(value, axis, relation, options)
-generated SUM      ┘
-```
-
-A vectorized wrapper must forward every type-relevant argument. Ignoring `condition`,
-`axis`, `where`, `keepdims`, fallback, key, cardinality, local axes, weights, or missing
-policy is nonconforming. The registry test harness mutates each type-relevant argument
-independently and requires the scalar, vectorized, and generated aliases to return the
-same resolved type or the same type-axis failure whenever their numerical semantics are
-equivalent.
-
-#### Return validation
-
-Each return expression is checked against the function's declared `TypeSpec`. Leaf
-checks cover all canonical axes, not only Pint dimensionality, and structural checks
-cover field names, container shape, and mapping signatures. A return is rejected when,
-for example:
-
-- wealth is declared as monthly income;
-- a household total is declared as a person amount;
-- a mean is declared as extensive;
-- an `Id[HH]` is declared as an unrestricted number;
-- a nullable branch is declared nonnullable;
-- a month-of-year ordinal is declared as a month duration; or
-- a concrete currency or provenance is incompatible with the regime.
-
-A function with no verified body may still expose its declared result to consumers only
-through a structured exemption. The consumer contract does not retroactively verify the
-producer.
+Branch exploration is bounded. Environment assembly fails when a body exceeds the
+implementation's documented path or decision limit; the author must simplify it or use a
+reported opt-out.
 
 (gep-10-date-partition)=
 
-### Maximal policy-date partition
+(gep-10-policy-dates)=
 
-Validation must cover every interval on which the resolved policy environment is
-structurally and typically constant. Testing only function start and end dates is
-insufficient.
+#### Exhaustive policy-date regimes
 
-Let `B` be the set of effective boundaries contributed by:
+A policy package is not validated exhaustively by testing function start dates alone.
+TTSIM constructs a half-open date partition from every boundary that can change the
+resolved unit environment.
 
-- policy-function and policy-input start dates;
-- the calendar day after each inclusive function or input end date;
-- every dated parameter value entry;
-- every dated parameter type, physical unit, period signature or convention, kind,
-  subject, extensity, index, local-axis, currency, nullability, leaf-set, or
-  mapping-axis entry;
-- parameter-function and structured-field schema changes;
-- schedule domain, arity, interpolation, and coefficient-schema changes;
-- statutory-currency start dates and conversion-rate regime changes;
-- period-conversion convention, factor, and date-aware rule regime changes;
-- rounding-rule starts and the day after inclusive ends;
-- relation, key-domain, cardinality, grouping, aggregation, and generated-node validity
-  changes;
-- naming or schema migrations that affect active declarations; and
-- the configured beginning and end of the policy package's supported date domain.
+The partition MUST include:
 
-The implementation sorts and deduplicates `B`. Each adjacent pair defines a half-open
-interval `[B_i, B_{i+1})`; the final boundary defines an open-ended interval if the
-policy domain permits one. Validation resolves the environment at the left endpoint of
-every interval. Inclusive end dates are represented by adding their successor date to
-`B`.
+- every function start date;
+- the day after every inclusive function end date;
+- every dated parameter entry, including entries that change only a value, unit, leaf
+  set, or currency;
+- every statutory-currency transition; and
+- every separately dated rounding-rule boundary not already represented by a function
+  boundary.
 
-Every boundary carries provenance identifying which declaration introduced it. The
-evidence report publishes the complete partition and the source boundaries.
+Boundaries are clipped to the policy package's supported date domain. At least one
+representative date, normally the left endpoint, is assembled and checked for every
+resulting interval.
 
-A parameter-only change therefore creates a new validation regime even when every
-function remains active. A currency-only or rounding-only change does the same.
-
-Runtime parameters may change magnitudes but MUST NOT change `ValueSpec`, leaf shape,
-index, local axes, key domain, or schedule arity within a compiled regime. Such
-structural dependence requires separate static regimes. Dynamic container shape or
-leaf-set variation is unsupported until a future explicit variant `TypeSpec` is
-standardized; an assertion cannot smuggle it through an ordinary `StructSpec` or
-`MappingSpec`.
+`ttsim.testing_utils.get_policy_date_partition` provides the reusable implementation for
+TTSIM policy packages. A parameter-only or currency-only change must open a regime even
+if the active function set is unchanged.
 
 (gep-10-evidence)=
 
-### Verification evidence and coverage
+(gep-10-coverage)=
 
-Every active producer in every date interval receives one primary evidence status and
-zero or more qualifiers. Compound producers additionally report a resolved `ValueSpec`
-and derivation for each active leaf.
+#### Validation reporting
 
-Required primary statuses are:
-
-```text
-BODY_VERIFIED
-DERIVED_BY_GENERATED_RULE
-INTERFACE_VERIFIED_ONLY
-DECLARED_ONLY_EXEMPTION
-UNSUPPORTED_BODY
-UNRESOLVED_TYPE
-```
-
-Required qualifiers include:
+Every environment check MUST expose a summary that distinguishes declaration coverage
+from body coverage. The exact class and field names are implementation details, but the
+report contains at least:
 
 ```text
-TYPE_ASSERTION_USED
-SEMANTIC_REASSIGNMENT_USED
-INPUT_TYPE_ASSUMED
-RUNTIME_RANGE_CHECKED
-CURRENCY_CONVERTED
-LEGACY_ADAPTER_USED
+resolved declarations
+checked function bodies
+generated nodes checked by rule
+local casts used
+function bodies opted out with verify_units=False
+bodies rejected as unsupported
+policy-date regimes checked
 ```
 
-Their meanings are:
+Counts alone are insufficient for exceptions. The report also lists the function or node
+names using `cast_ttsim_unit` or `verify_units=False`.
 
-- `BODY_VERIFIED`: the supported body and return were checked by the abstract
-  interpreter.
-- `DERIVED_BY_GENERATED_RULE`: the node has no ordinary body; a named relation,
-  aggregation, conversion, or graph-construction rule derived and checked its type.
-- `INTERFACE_VERIFIED_ONLY`: the declaration and boundary contract were checked, but the
-  producer body is external or otherwise outside the checker.
-- `DECLARED_ONLY_EXEMPTION`: a structured exemption supplies the consumer result
-  contract; the body was not verified.
-- `UNSUPPORTED_BODY`: the source uses unsupported syntax or an unregistered primitive.
-- `UNRESOLVED_TYPE`: one or more canonical axes could not be resolved.
+A project may say that all required declarations are present while still containing
+unchecked bodies. It may say that all non-exempt supported bodies passed the unit
+linter. It MUST NOT describe an opted-out body as verified, and it MUST NOT use “100%
+annotated” as a synonym for “100% body checked.”
 
-A package cannot pass the default conformance gate with `UNSUPPORTED_BODY` or
-`UNRESOLVED_TYPE`. An organization may permit listed `DECLARED_ONLY_EXEMPTION` nodes
-under an explicit policy, but it must not report them as verified.
+A suitable CI summary is, for example:
 
-The machine-readable report contains at least:
-
-```json
-{
-  "interval": ["2024-01-01", "2024-12-31"],
-  "node": "housing.amount_m_hh",
-  "resolved_value_type": {},
-  "primary_status": "BODY_VERIFIED",
-  "qualifiers": [],
-  "checker_version": "...",
-  "source_digest": "...",
-  "unit_system_digest": "...",
-  "primitive_registry_digest": "...",
-  "date_partition_digest": "...",
-  "derivation": [],
-  "assertions": [],
-  "exemptions": []
-}
+```text
+Declarations resolved: 412 / 412
+Bodies checked:         371
+Generated rules:         28
+Casts:                     9
+Body opt-outs:             4
+Unsupported bodies:        0
+Date regimes:             37
 ```
 
-The release summary reports separately:
+(gep-10-failures)=
 
-- active nodes and date intervals;
-- declaration-resolution coverage;
-- body-verified coverage;
-- generated-rule coverage;
-- interface-only coverage and the enumerated trusted external primitives;
-- assertion count and affected nodes;
-- semantic-reassignment count;
-- whole-body exemption count;
-- assumed-input count;
-- unsupported and unresolved counts; and
-- intervals validated versus intervals in the maximal partition.
+#### Failure diagnostics
 
-“100% annotated” is not a synonym for “100% body verified.” The report must not combine
-them into one percentage.
+A dimensional failure SHOULD identify the policy node, policy date or regime, source
+expression, expected unit, inferred unit, and the operation that failed. A branch or
+`xnp.where` failure SHOULD identify the condition or incompatible arm. A join failure
+SHOULD identify whether a key or fallback caused it. An unsupported reduction SHOULD
+name the reduction and explain that row or axis metadata is unavailable.
+
+Diagnostics must not recommend a generic cast as the default repair. They may state that
+a local cast or body opt-out is available, while making clear that either is an
+assertion or loss of body coverage.
+
+(gep-10-limitations)=
+
+#### Trade-offs and limitations
+
+**Dimensionless semantics are mostly unchecked.** `DIMENSIONLESS` covers shares, IDs,
+categories, bare rates, and ordinary scalars. The unit system cannot generally reject
+arithmetic between them. Truth compatibility excludes dimensioned values but does not by
+itself prove that a dimensionless selector is a Boolean.
+
+**Equality is unchecked.** Equality operators do not compare units. This permits
+sentinel comparisons such as `p_id_empfänger == -1`, but also means equality between
+monthly and yearly income is not detected.
+
+**Grouping markers are not relational grain.** They do not prove row alignment,
+uniqueness, cardinality, broadcast provenance, or the nominal domain of an ID. A bare
+household-specific share remains bare because this GEP does not model where it is
+stored.
+
+**The group algebra is intentionally partial.** Only documented head-count conversions,
+scalar modification, logical rules, and generated aggregations are checked. Other
+products or ratios involving group-marked quantities require an explicit assertion or
+opt-out.
+
+**Body exploration is bounded.** Code outside the explored paths or beyond the path
+limit is not silently certified.
+
+**Some operations are unsupported.** In-body array reductions are rejected. Joins
+receive only the dimensional checks documented above. Nominal domains and cardinality
+are not proved.
+
+**Annotated-input validation is partial.** It checks known tokens, exact suffix periods,
+and currency conversion. It does not compare every tag's physical dimension or grouping
+level with the target node declaration.
+
+**Automatic period ratios are conventions.** Their dimensional validity does not prove a
+statute-specific day-count, partial-period, or compounding rule. See
+[GETTSIM #1205](https://github.com/ttsim-dev/gettsim/issues/1205).
+
+**Currency provenance is regime-level.** The model assumes one statutory currency per
+policy regime and does not support simultaneous monetary values that retain distinct
+historical legal denominations inside one body.
+
+**A cast is an assertion.** An incorrect cast can hide an error. Casts are reported and
+must remain local.
 
 (gep-10-exceptions)=
 
 (gep-10-opt-out)=
 
-### Assertions, semantic conversions, and exemptions
+#### Explicit exceptions
 
-#### Typed literals
+`cast_ttsim_unit(value, unit=unit)` replaces the inferred unit of one expression during
+body linting. At numerical execution, it returns `value` unchanged.
 
-`quantity_literal` assigns a type to an implementation constant. It requires an
-`AssertionRef` that points to structured metadata. This operation is narrower than a
-generic type cast because it starts from a literal and cannot relabel an existing
-computed quantity.
+It is appropriate for:
 
-#### Semantic transformations
+- a policy-defined transfer between grouping concepts that the generic group algebra
+  cannot derive;
+- a dimensioned implementation constant that is not a statutory parameter; or
+- a narrow formula seam involving a known coefficient or operation outside the current
+  vocabulary.
 
-Alignment, subject reassignment, allocation, per-capita conversion, and calendar
-construction use named primitives with explicit preconditions and result rules. Their
-evidence names the relation or legal interpretation. They are not generic physical-unit
-conversions.
+It should apply to the smallest expression requiring the assertion. Every cast is listed
+in the validation report.
 
-#### Last-resort type assertion
+`verify_units=False` disables body linting for one decorated function or hand-written
+aggregation. Its declared output unit remains the contract used by consumers. It is
+appropriate only when the body:
 
-`assert_value_type(value, expected=..., assertion=...)` may supply unresolved axes or
-refine a broader nominal domain only when the standard type language cannot express a
-valid policy interpretation. It returns the runtime value unchanged. It MUST NOT
-contradict a known physical unit, period signature or convention, semantic kind,
-subject, index, local axis, concrete currency, or nullability. A known conflict requires
-a numerical conversion, named semantic transformation, boundary decoder, formula repair,
-or whole-producer exemption; it cannot be erased by assertion.
+- uses an unsupported operation;
+- exceeds the branch-exploration limit; or
+- implements a policy interpretation that cannot be represented by the documented unit
+  rules.
 
-Every assertion record contains:
-
-```python
-TypeAssertion(
-    id="GEP10-A012",
-    reason="Why the inferred and asserted types differ",
-    reference="Statute, design document, or derivation",
-    owner="team-or-person",
-    issue="tracking issue or permanent-decision record",
-    expires="2027-06-30",  # or permanent=True with justification
-)
-```
-
-The assertion applies to the smallest expression that requires it. It cannot be used to
-repair a known false declaration, such as relabeling wealth as monthly income, or to
-turn a family total into a person allocation. The checker records the unresolved or
-broad inferred type, the asserted refinement, and every affected consumer.
-
-#### Whole-body exemption
-
-A body exemption has the form:
-
-```python
-ValidationExemption(
-    id="GEP10-E004",
-    reason="Unsupported external primitive",
-    unsupported_construct="library.function",
-    owner="team-or-person",
-    issue="https://...",
-    expires="2027-03-31",
-)
-```
-
-An exempt function still declares a complete output `ValueSpec`, which consumers use as
-an interface contract. Its evidence status is `DECLARED_ONLY_EXEMPTION`. Missing
-metadata, an expired record, or an exemption not present in the policy package's
-reviewed manifest is a release error.
-
-The default CI policy rejects an increase in assertions or exemptions unless the change
-updates an approved manifest and its review record. A permanent exemption must name a
-stable external contract and explain why a typed primitive signature is not feasible.
-
-`verify_units=False` and unstructured casts are nonconforming.
-
-(gep-10-boundary)=
-
-### Input-boundary validation
-
-For fully typed input, every leaf has a source `ValueSpec`. Validation checks:
-
-- semantic kind and nominal domains;
-- physical-unit and period-specification compatibility;
-- subject and index compatibility;
-- representation, uniqueness, key, and local-axis requirements;
-- extensity;
-- calendar kind and axis;
-- currency denomination and provenance;
-- nullability; and
-- optional dtype, range, uniqueness, and finiteness contracts.
-
-Only registered physical, period, and currency conversions change magnitudes.
-Semantic-kind, subject, key-domain, category-domain, and calendar-kind mismatches are
-errors.
-
-Semantic kinds may imply value constraints that are not purely static. Fully typed
-boundaries MUST check boolean representation, identifier and primary-key validity,
-category-domain membership, integer-valued counts, declared count nonnegativity,
-probability range, and calendar-ordinal ranges. Other share or rate ranges are checked
-when their declaration supplies a constraint. Computed values receive
-`RUNTIME_RANGE_CHECKED` only when an enabled runtime validator actually checks them; a
-static `BODY_VERIFIED` status alone does not prove ranges.
-
-For untyped input, the policy node supplies the expected `ValueSpec`; `data_currency`
-supplies a monetary-denomination assumption. The evidence uses `INPUT_TYPE_ASSUMED`. The
-system may still perform GEP 9 dtype checks, key uniqueness checks, and configured
-value-range checks.
-
-Typed output contains the fully resolved result type. A requested raw parameter retains
-its own statutory type and is not relabeled as a computed output in data currency.
-
-(gep-10-failures)=
-
-### Failure policy and diagnostic requirements
-
-Validation is fail-closed. An unknown operation, missing type axis, incompatible
-relation, or uncovered date interval is an error unless a valid structured exemption
-applies.
-
-Diagnostics must identify:
-
-- the node and date interval;
-- source location and expression;
-- the complete left and right or expected and actual value types;
-- the specific axis that failed;
-- any relation, key, or aggregation involved;
-- the derivation path for generated fields; and
-- the assertion or exemption that would be required, without suggesting a generic cast
-  as the default repair.
-
-For branch failures, diagnostics identify the syntactic branch and both arm types. For
-scalar and vectorized variants, equivalent source expressions should produce equivalent
-diagnostics.
-
-A failure in one interval does not suppress analysis of other intervals when the checker
-can continue safely; the final report may aggregate failures. A package cannot claim
-conformance until all blocking failures are resolved.
+Every opt-out is listed separately and does not increase checked-body coverage. A policy
+package with opt-outs may be declaration-complete and may pass environment assembly; it
+must not claim that every body was unit checked.
 
 (gep-10-conformance)=
 
 ## Conformance and acceptance requirements
 
-An implementation conforms to this GEP only if all mandatory requirements below are met.
-Green project tests without these cases are not sufficient evidence.
+An implementation conforms to this GEP only if it satisfies all of the following:
 
-### Core type-model requirements
+1. every required object has a valid declaration under the compositional vocabulary;
+1. group-level dimensionless declarations are restricted to known counts and indicators;
+1. the restricted group algebra rejects unsupported products, ratios, and cross-level
+   operations;
+1. `MEAN`, `MIN`, and `MAX` derive the target group level;
+1. scalar truth contexts and `xnp.where` reject values with physical or period content;
+1. supported joins inspect keys and fallbacks, while unsupported join semantics are
+   documented rather than implied;
+1. raw in-body reductions fail when their result level cannot be derived;
+1. the policy-date partition includes function, parameter, rounding, and statutory-
+   currency boundaries as applicable;
+1. one statutory currency is enforced throughout each policy regime; and
+1. validation output distinguishes declarations, checked bodies, generated rules, casts,
+   and whole-body opt-outs.
 
-1. The canonical leaf type separates physical unit, period signature and convention,
-   semantic kind, subject, relational index, local tensor axes, extensity, calendar
-   semantics, currency provenance, and nullability; compound values use structural
-   `TypeSpec` variants.
-1. Pint is used only for physical-unit algebra and conversion. Entity domains and
-   semantic kinds are not Pint dimensions.
-1. Dimensionless values are not accepted without a semantic kind.
-1. Identifiers and categories use nominal domains.
-1. Currency denomination and provenance are checked separately from physical currency
-   dimension.
-1. The complete resolved type is serializable canonically and hashable for graph
-   validation and evidence.
-1. Type vocabularies, period systems, and primitive registries are immutable and
-   environment-local; construction, import order, threads, and concurrent validation do
-   not change another environment's accepted vocabulary or rules.
-
-### Expression-language requirements
-
-The conformance suite must include at least the following mutation tests.
-
-| Case                                                                                                                                        | Required result                                                                      |
-| ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| use currency, wealth, count, ID, or category in Python `if`, `and`, `or`, `not`, `bool()`, or `assert`                                      | reject as nonboolean truth context                                                   |
-| use a boolean array directly in Python `if`, `and`, `or`, `not`, `bool()`, or `assert`                                                      | reject as nonscalar truth context                                                    |
-| use any `while` loop in the initial language                                                                                                | reject as `UNSUPPORTED_BODY`; never validate it through placeholder truth evaluation |
-| use `for`, a comprehension, `match`, a closure with unresolved captures, reflection, mutation, or exception-driven control flow             | reject deterministically as `UNSUPPORTED_BODY` until a sound rule is registered      |
-| call an unregistered `numpy`, `xnp`, helper, or dynamically resolved function                                                               | reject; never execute a metadata-dropping fallback                                   |
-| branch on array shape, row count, or another runtime value through unsupported Python control flow                                          | reject rather than certify one observed path                                         |
-| use the same nonboolean values as `xnp.where` condition                                                                                     | reject with the same kind rule                                                       |
-| use aligned boolean array as `xnp.where` condition with matching arms                                                                       | accept                                                                               |
-| use nullable boolean as condition without a missing-condition policy                                                                        | reject                                                                               |
-| fill nullable boolean explicitly and use it as condition                                                                                    | accept as nonnullable boolean                                                        |
-| replace a scalar conditional with its equivalent vectorized conditional                                                                     | same resolved type or same failure                                                   |
-| compare monthly and annual income with equality                                                                                             | reject unless an explicit generated period conversion aligns them                    |
-| compare `Id[HH]` with `Id[BG]`                                                                                                              | reject                                                                               |
-| compare optional `Id[HH]` with `MISSING_ID[HH]`                                                                                             | accept as nonnullable `is_missing` test                                              |
-| combine nullable arithmetic operands                                                                                                        | result nullability is the union of operand nullability                               |
-| compare `Id[HH]` with literal `-1`                                                                                                          | reject inside policy code                                                            |
-| add `COUNT[PERSON]` to `COUNT[PERSON]` at the same subject and index                                                                        | accept as `COUNT[PERSON]`                                                            |
-| add `COUNT[PERSON]` to `COUNT[HH]` or to an unrestricted number                                                                             | reject                                                                               |
-| add wealth stock to monthly income                                                                                                          | reject                                                                               |
-| return wealth from a function declared as monthly income                                                                                    | reject                                                                               |
-| multiply a monthly income by a correctly typed month-per-currency coefficient under the same period and currency conventions                | accept with dimensionless result                                                     |
-| use an inverse-currency coefficient in a different denomination without conversion                                                          | reject before currency factors cancel                                                |
-| declare the coefficient dimensionless                                                                                                       | reject the formula                                                                   |
-| apply a fixed annualized conversion to an actual-day statutory amount                                                                       | reject; require the named date-aware rule                                            |
-| use nonzero bare threshold against dimensioned amount                                                                                       | reject                                                                               |
-| use typed zero against dimensioned amount                                                                                                   | accept and record its contextual type                                                |
-| use `1 - probability` or `share <= 1`                                                                                                       | accept through the contextual one rule                                               |
-| use one as count, ID, calendar point, or dimensioned amount                                                                                 | reject                                                                               |
-| use zero as ID or calendar point                                                                                                            | reject                                                                               |
-| apply `log` to a share, count, or identifier                                                                                                | reject unless a specialized primitive is registered                                  |
-| call a schedule with the wrong arity, axis kind, calendar axis, category domain, or fallback type                                           | reject at the call site                                                              |
-| mutate a schedule wrapper so that it drops a coordinate, interpolation rule, extrapolation rule, or fallback                                | fail registry parity or argument-mutation tests                                      |
-| evaluate a polynomial whose order-`j` coefficient lacks type `Y / X^j`                                                                      | reject the coefficient or evaluation                                                 |
-| access an absent or untyped structured field                                                                                                | reject; do not return an opaque placeholder type                                     |
-| swap two differently typed structured fields while keeping container shape                                                                  | reject from field lineage or return validation                                       |
-| mutate a generated period conversion so that it changes subject, index, local axes, extensity, calendar semantics, currency, or nullability | reject the derived node                                                              |
-| use `assert_value_type` to relabel wealth stock as monthly income                                                                           | reject the assertion as contradicting a known type                                   |
-
-Every scalar, vectorized, and generated alias in the public operation inventory must be
-covered by registry-generated parity and independent-argument mutation tests. A boolean
-condition, reduction axis, fallback, key, relation, or option omitted by a wrapper must
-cause a test failure.
-
-### Reference-period requirements
-
-The conformance suite must show that:
-
-- standard monthly and annual flows convert through a named exact annualized rule and
-  round-trip under the exact arithmetic reference implementation;
-- inverse and higher-power period coefficients use the exponent-aware factor;
-- source and target conventions appear in the resolved type and conversion evidence;
-- an actual-day, leap-year, 30/360, or statute-specific amount is not converted by the
-  standard fixed-ratio rule;
-- a date-aware proration primitive receives the complete required calendar context and
-  publishes its rule identifier; and
-- two independent `PeriodSystem` instances cannot leak conventions or factors into one
-  another.
-
-### Relation and aggregation requirements
-
-The conformance suite must show that the implementation:
-
-- rejects a join whose foreign and primary key domains differ;
-- rejects a monetary value, rate, or category used as a key;
-- checks primary-key uniqueness and declared cardinality;
-- rejects a join result declared nonnullable when the foreign key or missing policy can
-  produce `MISSING`;
-- rejects a fallback whose type differs from the target;
-- rejects a join, lookup, reduction, or aggregation whose possible missing values lack
-  an explicit policy;
-- distinguishes missing source values from an empty target group and rejects a reducer
-  without a valid empty-group policy;
-- preserves target semantics and records the new row index after a gather;
-- rejects summing a group value repeated on person rows without deduplication;
-- derives a group sum as extensive at the target subject;
-- derives a mean as intensive at the target subject while preserving the physical unit;
-- derives numeric `MIN`, `MAX`, and policy-defined `FIRST` as `STATISTIC` at the target
-  subject;
-- rejects a weighted mean with misaligned, negative under the standard rule,
-  dimensioned, or undeclared-normalization weights and checks its zero-weight policy;
-- keeps `mean_per_member()` at target subject even when broadcast to source rows;
-- derives `allocate_equal()` at source subject and verifies its declared conservation
-  and zero-count policy;
-- rejects a declaration that substitutes one of those meanings for the other;
-- derives boolean sum as a typed count of the source entity;
-- rejects a count whose counted entity is unspecified;
-- checks local axes, row axes, `where`, weights, `keepdims`, and row metadata for
-  in-body reductions;
-- distinguishes reduction over a local choice axis from aggregation over person rows;
-  and
-- rejects a reduction over an untyped axis;
-- preserves a household row grain idempotently under valid pointwise multiplication
-  instead of multiplying or cancelling a fictitious group dimension; and
-- handles zero-length sources and empty target groups according to the declared
-  identity, missing, or error policy.
-
-### Calendar requirements
-
-The conformance suite must show that:
-
-- year point minus year point returns a year duration;
-- year point plus year duration returns a year point;
-- year point plus year point is rejected;
-- quarter, month, and day ordinals reject fractional and out-of-range representations;
-- a complete date rejects an invalid day, including February 29 in a non-leap year;
-- month of year plus month duration is rejected;
-- a year-month point plus month duration wraps through years under an explicit
-  convention;
-- a date point plus month duration requires a defined end-of-month rule;
-- a calendar point cannot be compared with a duration; and
-- policy flow-period conversion is not dispatched through calendar arithmetic.
-
-### Currency requirements
-
-The conformance suite must include:
-
-- at least two statutory denominations and a changeover date;
-- parameters and inverse- and squared-currency coefficients declared in each regime's
-  concrete denomination;
-- exponent-aware conversion of ordinary amounts, inverse-currency coefficients, and
-  integer higher powers, plus rejection of a noninteger currency exponent at the
-  standard boundary;
-- typed input in one denomination converted to another computation denomination;
-- statutory rounding before output conversion and a presentation view explicitly labeled
-  as nonstatutory in the target currency;
-- a carried-value case whose origin denomination differs from the current policy
-  denomination;
-- rejection of a carried value that is silently relabeled;
-- nullable monetary input with its missing mask preserved;
-- integer monetary input that would truncate under conversion;
-- finite floating input whose exact conversion would overflow, which must fail rather
-  than become infinity silently;
-- zero-length, largest-finite, subnormal, positive- and negative-zero, NaN, and infinity
-  cases under the declared dtype and data-validity policy;
-- object-dtype rejection or a registered converter;
-- the same exact rate, exponent, and operation order in NumPy and JAX front ends; and
-- two independent `UnitSystem` instances whose registrations do not interfere.
-
-### Date-regime requirements
-
-The conformance suite must construct and validate a maximal partition with independent
-boundaries from:
-
-- a function start or end;
-- a parameter value change;
-- a parameter physical-unit, period-signature, or period-convention change with no
-  function boundary;
-- a parameter leaf-set, index, local-axis, or schedule-axis change;
-- a statutory-currency change;
-- a period-conversion rule or convention change;
-- a rounding-rule change; and
-- a relation or aggregation-schema change.
-
-For every inclusive start and end declaration used by the test fixture, the suite
-validates the exact start, the exact end, and the successor of the end when it lies in
-the supported domain. A mutation that inserts a wrong type only at a parameter-only date
-must fail. The evidence report must list the interval containing the mutation and the
-parameter boundary that created it.
-
-### Evidence and exception requirements
-
-The conformance suite must verify that:
-
-- every active node and interval has one primary evidence status;
-- a body exemption never counts as body verified;
-- `verify_units=False`, an unstructured full-type cast, and an unmanifested opt-out are
-  rejected;
-- a type assertion records inferred and asserted types;
-- an expired or unmanifested assertion or exemption fails the release gate;
-- unsupported syntax fails closed;
-- crossing a checker resource limit is visible and nonverified;
-- bare input is reported as assumed, while fully typed input is reported separately;
-- the four public claim levels are computed from evidence and cannot be selected
-  manually; and
-- coverage percentages cannot hide assertions, exemptions, unsupported bodies, trusted
-  external primitives, or untested date intervals.
-
-### Worked-example acceptance
-
-The bundled worked example must meet all of the following.
-
-1. Every active node, parameter leaf, local and schedule axis, rounding rule, join,
-   aggregation, compound field, and result has a complete resolved `TypeSpec` in every
-   maximal date interval.
-1. All ordinary body-bearing functions are `BODY_VERIFIED`; the worked example contains
-   no `DECLARED_ONLY_EXEMPTION` node.
-1. No function relabels a stock as a flow, a group total or group mean as a person
-   allocation, or an ID as a number.
-1. Parameter-only, period-convention-only, local-axis-only, currency-only, and
-   rounding-only date regimes are included.
-1. Every assertion and semantic reassignment appears in a reviewed manifest.
-1. The adversarial tests above pass for both supported NumPy and JAX execution front
-   ends.
-1. Typed and untyped boundaries return numerically identical values after expected
-   conversion, while their evidence correctly differs.
+Green project tests without these cases are not sufficient evidence of conformance. The
+implementation test suite SHOULD include adversarial mutations for each rule, including
+stock-versus-flow returns, dimensioned truth conditions, vectorized conditions, wrong
+join fallbacks, group-level shares, group means, parameter-only dates, and currency-only
+dates.
 
 ## Related work
 
-- {ref}`GEP 1 <gep-1>` defines policy-node naming conventions and generated
-  reference-period conversions.
-- {ref}`GEP 2 <gep-2>` defines grouping and identifier concepts.
-- {ref}`GEP 4 <gep-4>` defines the DAG and generated aggregation architecture.
+- {ref}`GEP 1 <gep-1>` defines the time and grouping suffixes validated here.
+- {ref}`GEP 2 <gep-2>` defines `*_id` columns and group creation.
+- {ref}`GEP 4 <gep-4>` defines the DAG, aggregations, and generated reference-period
+  conversions.
 - {ref}`GEP 5 <gep-5>` defines rounding specifications.
-- {ref}`GEP 9 <gep-9>` defines runtime type checking and the user/canonical type split.
-- [Pint](https://pint.readthedocs.io/) supplies physical-unit parsing, equivalence, and
-  conversion.
-- Nominal ID and category domains follow the same principle as newtypes or branded types
-  in static type systems: equal representation does not imply substitutability.
-- The syntax-directed checker follows ordinary abstract-interpretation and typed-IR
-  practice: it is conservative over a specified language rather than an execution-based
-  test of arbitrary Python behavior.
+- {ref}`GEP 9 <gep-9>` defines runtime type validation and the user/canonical data
+  split.
+- [Pint](https://pint.readthedocs.io) supplies the physical-unit registry and algebra.
+- [GETTSIM #1205](https://github.com/ttsim-dev/gettsim/issues/1205) tracks legally
+  sensitive reference-period conventions.
+- [GETTSIM #1219](https://github.com/ttsim-dev/gettsim/issues/1219) records the review
+  that led to the narrowed guarantee and additional guards in this revision.
 
 ## Implementation
 
-The implementation is divided into ordered phases. A later phase must not claim
-conformance while a required earlier phase remains a permissive placeholder.
+The implementation is divided between TTSIM infrastructure and policy-system
+annotations.
 
-### Phase 1: canonical type core
+- TTSIM [#138](https://github.com/ttsim-dev/ttsim/pull/138) contains the unit registry,
+  compositional vocabulary, declarations, generated aggregation rules, body linter, and
+  input-boundary machinery.
+- TTSIM [#141](https://github.com/ttsim-dev/ttsim/pull/141) annotates the bundled
+  fictional METTSIM policy system.
+- TTSIM [#150](https://github.com/ttsim-dev/ttsim/pull/150) tightens truth contexts,
+  `xnp.where`, join operands, unsupported reductions, the stock/flow reproducer, and the
+  policy-date partition.
+- GETTSIM [#1193](https://github.com/ttsim-dev/gettsim/pull/1193) contains GEP 10.
+- GETTSIM [#1212](https://github.com/ttsim-dev/gettsim/pull/1212) contains the GETTSIM
+  rollout.
 
-- Implement immutable `ValueSpec`, `StructSpec`, `MappingSpec`, `PhysicalUnit`,
-  `PeriodSpec`, `PeriodSignature`, `PeriodConvention`, `SemanticKind`, `SubjectSpec`,
-  `IndexSpec`, `AxisSpec`, `Extensity`, `CalendarSpec`, `CurrencySpec`, and nullability.
-- Keep Pint behind the `PhysicalUnit` boundary.
-- Implement canonical serialization, equality, hashing, diagnostics, and structured YAML
-  parsing.
-- Replace process-global registration with immutable `UnitSystem` instances.
-- Implement complete constructors under `Q` and a legacy migration adapter that cannot
-  claim full verification.
+Before this GEP is described as implemented, the code and test suite must additionally
+cover the normative changes introduced by this revision:
 
-### Phase 2: declarations and graph resolution
-
-- Migrate decorators, policy inputs, parameters, structured fields, schedules, rounding
-  rules, and typed columns to `value_type` declarations.
-- Resolve every canonical axis before graph validation.
-- Add nominal key and category domains.
-- Represent generated period conversions with named conventions, relations, joins,
-  broadcasts, allocations, and aggregations as typed graph nodes.
-- Implement suffix consistency checks without using suffixes as the only type source.
-
-### Phase 3: typed expression interpreter
-
-- Lower the supported Python subset to a typed IR.
-- Implement syntax-directed branch analysis and return checking.
-- Create one primitive registry for scalar, vectorized, and generated operations.
-- Implement boolean truth-context checks, typed equality, typed zero and missing
-  literals, conditionals, schedules, structured access, and full operation diagnostics.
-- Reject unsupported syntax and unregistered primitives.
-
-### Phase 4: relations, axes, and aggregation
-
-- Implement `RelationSpec`, key-domain checks, uniqueness, cardinality, and missing
-  policies.
-- Implement typed gather, broadcast, subject reassignment, target-level per-member
-  statistics, equal and weighted allocation, and count scaling.
-- Implement aggregation and local-array axis semantics, including repeated-value
-  protection.
-- Require every reduction wrapper to forward all type-relevant arguments.
-
-### Phase 5: calendar and currency
-
-- Implement distinct calendar points, durations, and ordinals, plus date-aware statutory
-  period conversions that cannot be confused with standard annualized conversion.
-- Correct the types of policy and evaluation date components.
-- Implement environment-local currency families, statutory histories, provenance,
-  carried-value rules, typed coefficients, and boundary conversion ordering.
-- Implement dtype-safe numerical conversion and typed rounding regimes.
-
-### Phase 6: date partition and evidence
-
-- Implement the maximal date-partition algorithm.
-- Validate every interval and publish boundary provenance.
-- Implement evidence statuses, qualifiers, source digests, derivations, coverage,
-  assertion and exemption manifests, and the default release gate.
-
-### Phase 7: worked example and GETTSIM rollout
-
-- Migrate METTSIM without proof-erasing stock-to-flow, group-to-person, or coefficient
-  casts.
-- Run the complete conformance and adversarial suite across every date interval.
-- Migrate GETTSIM policy declarations and historical currency regimes.
-- Retain untyped input compatibility while distinguishing assumed from verified boundary
-  types.
-
-### Existing pull requests
-
-The following pull requests are prototypes for parts of the original GEP and are not, by
-their current existence alone, implementations of this revised specification.
-
-- [TTSIM #138](https://github.com/ttsim-dev/ttsim/pull/138) must replace the
-  compositional group-dimension model, permissive placeholder behavior, and
-  process-global vocabulary with the canonical value type, typed IR, relation rules,
-  evidence, and local registries above. It must in particular validate every truth
-  context, `where` condition, join argument, fallback, cardinality, reduction axis, and
-  date regime.
-- [TTSIM #141](https://github.com/ttsim-dev/ttsim/pull/141) must migrate the worked
-  example to the revised declarations, remove stock-as-monthly-flow annotations, fully
-  type coefficients and group operations, and validate the maximal date partition
-  including parameter-only changes.
-- [GETTSIM #1193](https://github.com/ttsim-dev/gettsim/pull/1193) contains the GEP
-  discussion and is the target for this text.
-- The GETTSIM rollout must not claim completion until the TTSIM infrastructure and
-  worked example pass the conformance requirements in this document.
-
-A PR may land in phases, but the public feature remains experimental until the complete
-required stack is present. Documentation and evidence must identify partial
-implementations precisely.
+- prohibit group-level dimensionless shares and rates while retaining documented group
+  counts and indicators;
+- restrict generic products and ratios of group-marked quantities;
+- derive `MEAN` at the target group rather than automatically making it bare;
+- report casts and whole-body opt-outs separately from checked bodies; and
+- align public calendar wording with the ordinal semantics specified here.
 
 (gep-10-alternatives)=
 
 ## Alternatives
 
-### Encode grouping levels as Pint dimensions
+### A general multi-axis value-type system
 
-Rejected. A subject or row grain is not a physical denominator. Pointwise multiplication
-of two household-indexed values would incorrectly square a household dimension, while
-division would cancel it even though the result remains household-indexed. Means,
-minima, maxima, joins, and broadcast representations also cannot be represented
-faithfully by this algebra.
+Deferred. A broader design could represent physical unit, semantic kind, row index,
+nominal key domain, extensity, tensor axes, calendar semantics, currency provenance, and
+nullability as independent type axes. Such a system could validate joins, row alignment,
+group-specific shares, inverse-unit coefficients, and more of the Python expression
+language.
 
-### Treat all nonphysical values as dimensionless
+That design is substantially larger than the dimensional guards needed for the current
+GETTSIM and METTSIM rollout. This GEP instead states the limits of the Pint-centered
+model and fails closed where a supported operation would otherwise be falsely certified.
+A later GEP may add relational or semantic typing without changing the physical-unit
+rules here.
 
-Rejected. Booleans, IDs, categories, shares, probabilities, rates, and counts support
-different operations and nominal domains. A dimensionless catch-all permits nonsense
-such as adding an ID to a tax rate or using wealth as a condition.
+### A dedicated public `SHARE` or identifier unit
 
-### Use one implied person level and group denominators
+Deferred. Pint would still treat a share as physically dimensionless, so meaningful
+semantic restrictions would require a separate rule system. The present GEP prefers
+fewer public unit kinds and explicitly documents the dimensionless blind spot. It adds
+only the truth and group-declaration guards needed for the claims made here.
 
-Rejected. This still conflates physical algebra with relational ownership and storage
-layout. It cannot represent a household value repeated on person rows without either
-losing the household subject or inviting double counting.
+### A complete relational grain model
 
-### Infer meaning from node names and suffixes
+Deferred. Grouping levels in this GEP are restricted arithmetic markers, not row-domain
+types. Nominal ID domains, uniqueness, join cardinality, broadcast provenance, and
+alignment remain outside scope. Unsupported reductions fail rather than pretending that
+their row grain is unchanged.
 
-Rejected as the primary type source. Suffixes are valuable redundant checks but do not
-encode semantic kind, extensity, key domain, nullability, representation, join
-cardinality, calendar kind, coefficient units, or currency provenance.
+### A person level, implied or spelled
 
-### Execute functions on placeholder quantities and call the result verified
+Rejected for this proposal. Earlier variants represented every person amount as
+`... / [person]` and head counts as `[person] / [group]`. This distinguished a bare rate
+or share from a per-person amount, but introduced an implied level on almost every value
+and two spellings for the same practical person quantity.
 
-Rejected as the specification model. Placeholder execution can be a useful
-implementation aid, but path choices, hand-written stand-ins, Python truth semantics,
-unsupported operations, and bounded exploration make it unsuitable as the assurance
-contract. The adopted design specifies a syntax-directed typed interpreter and publishes
-unsupported code explicitly.
+The adopted model keeps person quantities bare and uses group head counts as
+`1 / [group]`. The consequence is explicit: after total/head-count division, the unit
+checker knows that the result is bare but does not maintain a separate person-grain
+type.
 
-### Leave equality unchecked
+### Convert every parameter to a selected run currency
 
-Rejected. The legacy missing-ID use case is handled by typed optional identifiers and
-missing sentinels. Blanket equality exemption would allow monthly and annual amounts or
-unrelated ID domains to compare silently.
+Rejected. Some statutory formulas contain coefficients whose numerical values depend on
+the currency convention. Converting only the obvious monetary quantities could change
+the formula. The adopted design evaluates each regime entirely in its statutory
+currency, retains parameter and coefficient values as written, and converts only input
+and computed output at the boundary.
 
-### Let `where`, joins, and reductions preserve the result-arm or target unit
+### Pass Pint quantities through the DAG
 
-Rejected. Conditions, keys, domains, cardinality, fallbacks, axes, uniqueness, and
-extensity are part of the operation's correctness. Ignoring them creates ordinary false
-negatives.
+Rejected. `pint.Quantity` is not part of the intended NumPy/JAX numerical
+representation. Units are static properties checked during environment assembly and at
+interface boundaries. The compiled tax-and-transfer function continues to receive
+ordinary numeric values.
 
-### Use generic casts and whole-body opt-outs
+### Remove concrete currency labels from parameters
 
-Rejected as the normal workflow. Typed literals, relation-mediated alignment, subject
-reassignment, allocation, calendar construction, and registered primitives cover
-distinct valid cases. A last-resort assertion or exemption remains available but carries
-structured evidence and never counts as verified.
-
-### Convert every statutory parameter into the caller's data currency
-
-Rejected. Legally rounded changeover values and currency-dependent coefficients must
-retain their statutory numerical representation. The adopted design computes in the
-statutory denomination, while requiring complete units for coefficients and explicit
-conversion at data boundaries.
-
-### Omit units for coefficients not printed with units in statutes
-
-Rejected. Mathematical dimensionality follows from the formula, not typography. An
-inverse-income coefficient must declare the inverse unit and period required to make the
-formula well typed.
-
-### Pass Pint quantities through the compiled DAG
-
-Rejected. Static `ValueSpec` metadata and boundary conversion provide the intended
-validation without placing Pint objects inside JAX traces or changing runtime array
-representation.
-
-### Treat month of year and day of month as affine points
-
-Rejected. They are cyclic or contextual ordinals. Valid affine arithmetic requires a
-year-month or complete date point and an explicit wrap or end-of-month convention.
-
-### Validate only dates where functions start or stop
-
-Rejected. Parameters, leaf schemas, currencies, rounding, schedules, and relations can
-change while the same functions remain active. The maximal partition is required.
-
-### Report a single annotation-coverage percentage
-
-Rejected. Declaration coverage, body verification, generated-rule derivation,
-assertions, exemptions, assumed inputs, unsupported bodies, and date coverage convey
-different evidence and must remain separate.
+Rejected. The one-currency-per-regime invariant would make these labels theoretically
+redundant, but they are useful validation checks and documentation. A parameter declared
+in Euro during a Deutsche-Mark regime should fail loudly.
 
 ## Discussion
 
-- [GETTSIM #1193: GEP 10 discussion](https://github.com/ttsim-dev/gettsim/pull/1193)
-- [TTSIM #138: original infrastructure prototype](https://github.com/ttsim-dev/ttsim/pull/138)
-- [TTSIM #141: original METTSIM worked-example prototype](https://github.com/ttsim-dev/ttsim/pull/141)
+- [GETTSIM #1193: GEP 10 — Units and Dimensionality](https://github.com/ttsim-dev/gettsim/pull/1193)
+- [GETTSIM #1219: review of GEP 10 and its prototype implementation](https://github.com/ttsim-dev/gettsim/issues/1219)
+- [TTSIM #138: units and dimensionality infrastructure](https://github.com/ttsim-dev/ttsim/pull/138)
+- [TTSIM #141: METTSIM annotations](https://github.com/ttsim-dev/ttsim/pull/141)
+- [TTSIM #150: targeted GEP-10 guards and date regimes](https://github.com/ttsim-dev/ttsim/pull/150)
 
 ## References and footnotes
 
-- [Pint documentation](https://pint.readthedocs.io/)
-- [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119)
-- [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174)
+- [GETTSIM #1174: discussion of Deutsche-Mark values](https://github.com/ttsim-dev/gettsim/issues/1174)
+- [GETTSIM #1205: reference-period conversion conventions](https://github.com/ttsim-dev/gettsim/issues/1205)
+- [Pint](https://pint.readthedocs.io)
 - [NEP 18: NumPy array-function protocol](https://numpy.org/neps/nep-0018-array-function-protocol.html)
 
 ## Copyright

--- a/docs/geps/gep-10.md
+++ b/docs/geps/gep-10.md
@@ -167,7 +167,7 @@ For this example, GETTSIM:
 
 1. recognizes Deutsche Mark as the currency of the law on 1999-01-01;
 1. converts monetary input from Euro to Deutsche Mark;
-1. calculates the policy with the Deutsche-Mark parameters and rounding rules stated in
+1. calculates the policy with the Deutsche Mark parameters and rounding rules stated in
    the law;
 1. performs statutory rounding in Deutsche Mark; and
 1. converts the calculated monetary results back to Euro.
@@ -332,12 +332,6 @@ The unit calculation is:
 ```text
 CURRENCY * (1 / year) = CURRENCY / year.
 ```
-
-Units do not determine how a financial rate compounds. A linear annual rate can use the
-automatically generated conversion to a monthly flow. An effective annual rate that
-requires `(1 + r_y) ** (1 / 12) - 1`, a continuously compounded rate, or a legal
-proration rule MUST use an explicit conversion function. The unit tells us that the rate
-is annual; it does not tell us which financial convention applies.
 
 #### Parameters
 
@@ -1317,8 +1311,6 @@ default the first. The policy package's automated tests MUST assemble and check 
 environment at every returned date. A parameter-only or currency-only change must start
 a new interval even when no policy function changes.
 
-(gep-10-evidence)=
-
 (gep-10-coverage)=
 
 #### Validation report
@@ -1606,7 +1598,7 @@ formula. The adopted design calculates each regime entirely in its statutory cur
 keeps parameter and coefficient values as written, and converts only input and
 calculated output at the boundary.
 
-### Pass Pint quantities through the calculation graph
+### Pass Pint quantities through the DAG
 
 Rejected. `pint.Quantity` is not part of the intended NumPy/JAX numerical data. Units
 are checked while a policy environment is assembled and at its input and output

--- a/docs/geps/gep-10.md
+++ b/docs/geps/gep-10.md
@@ -27,20 +27,20 @@ example, it can distinguish:
 - total rent from rent per square meter; and
 - a household total from a total for a Bedarfsgemeinschaft.
 
-TTSIM uses these declarations to review the unit calculations in a policy environment,
+TTSIM uses these declarations to check the unit calculations in a policy environment,
 meaning the functions and parameters that apply on a particular policy date. When TTSIM
 assembles this environment, it runs supported policy formulas with test values that
-carry units. It rejects operations that do not make sense, such as adding a monthly
-amount to an annual amount or using an amount of money as the condition in an `if`
-statement.
+carry units. It rejects operations that are not dimensionally valid, such as adding a
+monthly amount to an annual amount or using an amount of money as the condition in an
+`if` statement.
 
-The check has clear limits. It does not establish that a formula implements the law
+The check is limited in scope. It does not establish that a formula implements the law
 correctly, that observations are matched to the right people, or that every physically
 dimensionless number has the right economic meaning. A share, an identifier, a category
 code, and a count are all dimensionless in the physical sense. The checker can
 distinguish them only in the special cases described in this GEP. Likewise, a household
 marker helps with selected calculations involving household totals and head counts, but
-it does not fully describe the variable's grain and does not replace checks of data
+it does not fully describe the variable's level and does not replace checks of data
 layout, merge keys, or group membership. If TTSIM does not know how an operation affects
 units, it must reject the operation or record an explicit exception.
 
@@ -65,14 +65,14 @@ This GEP addresses four recurring sources of mistakes.
 
 1. **The same storage type can represent different quantities.** In a DataFrame, a
    `float` column may contain wealth, monthly earnings, annual earnings, a share, or
-   square meters. Python, NumPy, and JAX normally allow arithmetic between these columns
-   even when the economic quantities are not compatible.
-1. **Group calculations can use the wrong grain.** Grain is the level at which a
-   variable is defined or varies, such as person, household, or Bedarfsgemeinschaft. A
-   household total can accidentally be combined with a Bedarfsgemeinschaft total. A
-   formula can also forget to divide a group total by the number of people in the group.
-   These mistakes are similar to using a variable produced by `egen total(), by(hh_id)`
-   as if it were a person-level value.
+   square meters. Python, NumPy, and JAX allow arithmetic between these columns without
+   error, even when the economic quantities are not compatible.
+1. **Group calculations can use the wrong level.** A variable's level is the person or
+   group for which it is defined or varies: a person, a household, or a
+   Bedarfsgemeinschaft. A household total can accidentally be combined with a
+   Bedarfsgemeinschaft total. A formula can also forget to divide a group total by the
+   number of people in the group. These mistakes are similar to using a variable
+   produced by `egen total(), by(hh_id)` as if it were a person-level value.
 1. **Historical policy parameters use different currencies.** German statutes contain
    both Deutsche-Mark and Euro amounts. Rewriting all historical values into one
    currency would obscure the values stated in the law and can change formulas that
@@ -81,8 +81,8 @@ This GEP addresses four recurring sources of mistakes.
    between years, quarters, months, weeks, and days. The same unit system should supply
    these standard ratios and check that the conversions are dimensionally possible.
 
-The design is deliberately focused. It uses [Pint](https://pint.readthedocs.io), a
-Python library for calculations with units, and covers:
+The scope is deliberately narrow. It uses [Pint](https://pint.readthedocs.io), a Python
+library for calculations with units, and covers:
 
 - physical units, reference periods, and a limited set of group markers built with Pint;
 - unit declarations for policy functions, inputs, parameters, schedules, structured
@@ -114,10 +114,9 @@ The GEP does **not** check:
   automatic period conversions.
 
 The naming rules and automatic period conversions in {ref}`GEP 1 <gep-1>`, group
-identifiers in {ref}`GEP 2 <gep-2>`, the map of how calculations depend on one another
-and the aggregation concepts in {ref}`GEP 4 <gep-4>`, rounding in {ref}`GEP 5 <gep-5>`,
-and the checks applied to values when the model runs in {ref}`GEP 9 <gep-9>` continue to
-apply.
+identifiers in {ref}`GEP 2 <gep-2>`, the directed acyclic graph of calculations and the
+aggregation concepts in {ref}`GEP 4 <gep-4>`, rounding in {ref}`GEP 5 <gep-5>`, and the
+checks applied to values when the model runs in {ref}`GEP 9 <gep-9>` continue to apply.
 
 (gep-10-guarantee)=
 
@@ -152,9 +151,9 @@ Documentation and continuous-integration output MUST report at least:
 
 ### Users of existing policy environments
 
-Most users continue to call `main()` with ordinary arrays, mappings, or a DataFrame. The
-optional `data_currency` argument states the currency of untagged monetary input and the
-currency requested for monetary results. In GETTSIM it defaults to Euro.
+Most users continue to call `main()` with unannotated arrays, mappings, or a DataFrame.
+The optional `data_currency` argument states the currency of untagged monetary input and
+the currency requested for monetary results. In GETTSIM it defaults to Euro.
 
 ```python
 results = main(
@@ -183,8 +182,8 @@ policy regime, a policy function does not receive a mixture of DM and EUR amount
 
 ### Unit-annotated data
 
-Users may optionally attach a unit to every input column. This is useful when a dataset
-comes with a known currency and reference period. In this input mode, every final entry
+Users may optionally attach a unit to every input column. This mode suits datasets that
+arrive with a known currency and reference period. In this input mode, every final entry
 in the nested input (called a leaf in the code) is a `UnitAnnotatedColumn`, including
 identifiers and other dimensionless columns.
 
@@ -236,8 +235,8 @@ units. They do not establish that a dimensionless value has the intended economi
 meaning or that observations are matched to the right people and groups.
 
 When users request `MainTarget.results.tree_with_unit_annotations`, calculated results
-include their resolved unit and output currency. The ordinary result targets continue to
-return plain numerical values.
+include their resolved unit and output currency. The unannotated result targets continue
+to return plain numerical values.
 
 ### Contributors and users extending policy environments
 
@@ -297,8 +296,8 @@ def incorrect_amount_m(
 #### Stocks, flows, shares, and rates
 
 A stock is measured at a point in time and has no period in its unit. A flow is measured
-per year, month, week, or day. Multiplying either by a simple share does not change
-whether it is a stock or a flow.
+per year, month, week, or day. Multiplying either by a dimensionless share does not
+change whether it is a stock or a flow.
 
 ```python
 @policy_input(unit=TTSIMUnit.CURRENCY)
@@ -335,10 +334,10 @@ CURRENCY * (1 / year) = CURRENCY / year.
 ```
 
 Units do not determine how a financial rate compounds. A linear annual rate can use the
-ordinary generated conversion to a monthly flow. An effective annual rate that requires
-`(1 + r_y) ** (1 / 12) - 1`, a continuously compounded rate, or a legal proration rule
-MUST use an explicit conversion function. The unit tells us that the rate is annual; it
-does not tell us which financial convention applies.
+automatically generated conversion to a monthly flow. An effective annual rate that
+requires `(1 + r_y) ** (1 / 12) - 1`, a continuously compounded rate, or a legal
+proration rule MUST use an explicit conversion function. The unit tells us that the rate
+is annual; it does not tell us which financial convention applies.
 
 #### Parameters
 
@@ -358,7 +357,7 @@ regime.
 
 ## Backward compatibility
 
-- Ordinary arrays, mappings, and DataFrame inputs remain supported.
+- Unannotated arrays, mappings, and DataFrame inputs remain supported.
 - `data_currency` defaults to `EUR`, so present-day Euro input and output keep their
   current denomination.
 - One combined unit name such as `EUR_PER_YEAR_PER_FG` replaces the separate
@@ -376,7 +375,7 @@ regime.
   it as unchecked. It MUST NOT count as a checked body.
 - `cast_ttsim_unit` remains available for a local unit assertion. The report lists each
   use separately from units inferred by TTSIM.
-- Unit checks are normally included when a policy environment is assembled. When
+- Unit checks are included by default when a policy environment is assembled. When
   explicit output targets are supplied, `include_fail_nodes=False` can omit unit-related
   failure checks from that call. Results from such a call MUST NOT be described as
   unit-validated, even though some invalid declarations may still be rejected earlier.
@@ -387,19 +386,19 @@ regime.
 
 ### Design principles
 
-1. **Use Pint for ordinary unit arithmetic.** Pint handles physical units and reference
+1. **Use Pint for dimensional arithmetic.** Pint handles physical units and reference
    periods. TTSIM adds only the policy-specific rules described here.
 1. **Use group markers for selected group calculations.** They help find mistakes in
-   totals, head counts, and indicators at different grains. They do not fully describe a
-   variable's grain or the layout of the data.
+   totals, head counts, and indicators at different levels. They do not fully describe a
+   variable's level or the layout of the data.
 1. **Describe the check accurately.** TTSIM checks a defined set of expressions. It does
    not prove arbitrary Python code correct.
 1. **Check every relevant argument.** If a condition, fallback value, key, period, or
    other argument can affect the unit of a supported operation, the checker MUST inspect
    it.
-1. **Reject unsupported changes of grain.** If an operation may change the level at
+1. **Reject unsupported changes of level.** If an operation may change the level at
    which a result is defined and TTSIM lacks the necessary array or grouping
-   information, the checker must not simply keep the old unit.
+   information, the checker must not retain the source unit.
 1. **Check every distinct policy regime.** A regime may change because a function,
    parameter, rounding rule, or statutory currency changes.
 1. **Keep exceptions visible.** A declaration, a generated rule, a checked body, a local
@@ -417,8 +416,9 @@ regime.
 | quantity           | A value with a unit, such as income, age, a share, or a head count.                                                                                                                                                              |
 | base               | What is measured in the numerator, such as `CURRENCY`, `DIMENSIONLESS`, or `YEARS`.                                                                                                                                              |
 | period             | A denominator such as `MONTH` or `YEAR` that identifies a flow or rate.                                                                                                                                                          |
-| grain              | The level at which a variable is defined or varies, such as person, household, or Bedarfsgemeinschaft.                                                                                                                           |
-| group marker       | A denominator such as `HH` or `BG` that checks selected amounts, counts, or indicators at that grain. It is not a complete representation of grain.                                                                              |
+| level              | The person or group for which a variable is defined or varies, such as person, household, or Bedarfsgemeinschaft.                                                                                                                |
+| group              | A level other than person, such as `HH` or `BG`, which may appear as a denominator.                                                                                                                                              |
+| group marker       | A denominator such as `HH` or `BG` that checks selected amounts, counts, or indicators at that level. It is not a complete representation of the level.                                                                          |
 | quantity kind      | Narrow supporting information—`GENERIC`, `COUNT`, or `INDICATOR`—used only when deciding whether a dimensionless value may carry a group marker. It belongs to one exact declared value or schedule axis and is not a Pint unit. |
 | stock              | A quantity without a period denominator, such as wealth.                                                                                                                                                                         |
 | flow               | A quantity with a period denominator, such as monthly income.                                                                                                                                                                    |
@@ -455,19 +455,19 @@ base        := CURRENCY
 
 physical    := SQUARE_METER | HOURS
 period      := MONTH | YEAR | QUARTER | WEEK | DAY
-level       := HH | BG | FG | SN | EG | EHE | WTHH | ...
+group       := HH | BG | FG | SN | EG | EHE | WTHH | ...
 
 unit        := base
              | base _PER_ physical
              | base _PER_ period
-             | base _PER_ level
+             | base _PER_ group
              | base _PER_ physical _PER_ period
-             | base _PER_ physical _PER_ level
-             | base _PER_ period _PER_ level
-             | base _PER_ physical _PER_ period _PER_ level
+             | base _PER_ physical _PER_ group
+             | base _PER_ period _PER_ group
+             | base _PER_ physical _PER_ period _PER_ group
 ```
 
-The fixed order makes declarations consistent and easy to read. For example,
+The fixed order gives each unit exactly one spelling. For example,
 `EUR_PER_MONTH_PER_YEAR` is invalid because it contains two period denominators.
 `EUR_PER_BG_PER_MONTH` is also invalid; the correct order is `EUR_PER_MONTH_PER_BG`.
 
@@ -515,9 +515,9 @@ rate or a group marker on a known count or indicator.
 
 For the restricted group-marker rules, TTSIM may record one narrow `QuantityKind`:
 `GENERIC`, `COUNT`, or `INDICATOR`. This information is not another public unit and does
-not generally distinguish economic meanings. It answers only whether one particular
-dimensionless declaration is independently known to be a count or yes/no indicator. Like
-any declaration supplied by an author, explicit `QuantityKind` metadata can be wrong; it
+not distinguish economic meanings. It answers only whether one particular dimensionless
+declaration is independently known to be a count or yes/no indicator. Like any
+declaration supplied by an author, explicit `QuantityKind` metadata can be wrong; it
 does not prove the economic meaning of the underlying data.
 
 The evidence is local. A scalar function or input, one leaf of a mapping, each input
@@ -536,37 +536,37 @@ require a separate system for economic meaning and data relations.
 
 (gep-10-levels)=
 
-### Grain and group markers
+### Levels and group markers
 
-In this GEP, **grain** is the level at which a variable is defined or varies. Examples
-are person, household, family unit, Bedarfsgemeinschaft, and tax unit. Grain is distinct
-from a physical unit. GEP 10 nevertheless uses group markers as a limited check for
-selected calculations across grains.
+In this GEP, a variable's **level** is the person or group for which it is defined or
+varies. Examples are person, household, family unit, Bedarfsgemeinschaft, and tax unit.
+A level is distinct from a physical unit. GEP 10 nevertheless uses group markers as a
+limited check for selected calculations across levels.
 
 GETTSIM stores one row per person and identifies that person with `p_id`. Columns such
 as `hh_id`, `fg_id`, `bg_id`, `sn_id`, `eg_id`, `ehe_id`, and `wthh_id` identify groups.
 See {ref}`GEP 2 <gep-2>`.
 
 A policy package registers its group levels in the unit system. This creates a
-`PER_<LEVEL>` component for each group. TTSIM treats the registered levels as different
+`PER_<GROUP>` component for each group. TTSIM treats the registered groups as different
 units, so a household (`HH`) cannot be substituted for a Bedarfsgemeinschaft (`BG`).
-There is no `PER_PERSON` component: a person-level amount has no group denominator.
+There is no `PER_PERSON` component: person is a level, not a group, so a person-level
+amount has no group denominator.
 
 #### What a group marker means
 
-A group marker is a limited check on grain; it is not the grain itself. A group marker
-may be used when a value is:
+A group marker is a limited check on the level; it is not the level itself. A group
+marker may be used when a value is:
 
 1. calculated or assigned for a particular target group; and
-1. an amount, count, or yes/no indicator for which the group calculations below make
-   sense.
+1. an amount, count, or yes/no indicator to which the group calculations below apply.
 
 Examples are total monthly rent per household, square meters per household, persons per
 household, and a household eligibility indicator.
 
 A group marker is not added merely because a value is stored once per group or repeated
-on every person in the group. In particular, shares, ordinary rates, and identifiers
-remain dimensionless without a group denominator:
+on every person in the group. In particular, shares, rates without a period, and
+identifiers remain dimensionless without a group denominator:
 
 ```text
 housing-cost share of a household     -> DIMENSIONLESS
@@ -580,7 +580,7 @@ all household members does not turn the share into a household total. GEP 10 doe
 check whether such repeated values are aligned with the correct rows.
 
 Declaration validation MUST enforce the following restriction. A direct
-`DIMENSIONLESS.PER_<LEVEL>` declaration is allowed only for a count or yes/no indicator
+`DIMENSIONLESS.PER_<GROUP>` declaration is allowed only for a count or yes/no indicator
 whose meaning is established independently of its unit **for that exact declaration**.
 Generated `COUNT`, the sum of a yes/no indicator, `ANY`, and `ALL` qualify
 automatically. A Boolean return type establishes an indicator. A directly declared
@@ -593,16 +593,16 @@ Evidence MUST NOT be borrowed from an enclosing object, sibling mapping leaf, an
 schedule axis, the schedule output, or another occurrence of the same nested structured
 type. General descriptions such as “number of children and rent class” do not establish
 that both components are counts. A floating-point share, probability, identifier,
-category, or ordinary rate with a group marker is rejected. If TTSIM cannot establish
-one of the permitted cases for the exact declaration carrying the marker, it MUST reject
-the declaration rather than guess.
+category, or rate without a period carrying a group marker is rejected. If TTSIM cannot
+establish one of the permitted cases for the exact declaration carrying the marker, it
+MUST reject the declaration rather than guess.
 
 #### Restricted group calculations
 
 TTSIM checks the following group calculations:
 
 1. Multiplying or dividing a group quantity by a quantity that has no group marker
-   follows ordinary unit arithmetic and keeps the group marker. For example, multiplying
+   follows dimensional arithmetic and keeps the group marker. For example, multiplying
    group wealth by an annual interest rate produces an annual group flow.
 1. Dividing a group total by the matching group head count removes the group marker and
    gives a person-level amount.
@@ -653,17 +653,17 @@ Policy formulas use conditions to choose between alternatives. GEP 10 does not a
 separate unit to yes/no values and does not attempt to distinguish the different
 meanings of dimensionless values.
 
-For conditions, TTSIM therefore applies only a **dimensional screen**. It rejects a
-value if it has a physical unit or a period. A value that passes this screen may be a
-yes/no value, an identifier, a count, a share, a category code, or another dimensionless
-scalar. Passing the screen means only that units do not rule out its use as a condition.
-It does not establish which of these meanings the value has.
+For conditions, TTSIM therefore requires only that the value be **dimensionless**. It
+rejects a value if it has a physical unit or a period. A value that meets this
+requirement may be a yes/no value, an identifier, a count, a share, a category code, or
+another dimensionless scalar. Meeting it means only that units do not rule out its use
+as a condition. It does not establish which of these meanings the value has.
 
 When a comparison or logical operation produces a yes/no result, TTSIM may use that fact
 when checking later operations. This information comes from the operation that produced
 the result, not from its `DIMENSIONLESS` unit.
 
-The same dimensional screen MUST apply to:
+The same dimensionless requirement MUST apply to:
 
 - Python `if` statements and conditional expressions;
 - `bool(value)` calls made while branches are checked;
@@ -685,7 +685,8 @@ scalar conditional as an array-valued `xnp.where` must not remove this check.
 When two yes/no results carry the same group marker, the result keeps that marker. If
 one is person-level and one is group-level, or if their group markers differ, the result
 is treated as person-level because the logical operation is evaluated row by row. This
-is a practical unit rule; it does not establish that the underlying rows are aligned.
+is a convention about the resulting unit; it does not establish that the underlying rows
+are aligned.
 
 Ordering comparisons such as `<` and `>=` require compatible units and produce a
 dimensionless yes/no result. Equality comparisons do not compare units, for the reasons
@@ -697,9 +698,9 @@ given in {ref}`Trade-offs and limitations <gep-10-limitations>`.
 
 #### Working hours
 
-Working hours use their own `[hours]` dimension. They are not represented as ordinary
-calendar time. Otherwise, “hours per week” would simplify to a dimensionless fraction
-and could not be distinguished from a share.
+Working hours use their own `[hours]` dimension. They are not represented as calendar
+time. Otherwise, “hours per week” would simplify to a dimensionless fraction and could
+not be distinguished from a share.
 
 `HOURS_PER_WEEK` therefore means `[hours] / [time]`.
 
@@ -874,11 +875,11 @@ only to the output and MUST NOT authorize an input axis. An arity mismatch is a
 declaration error.
 
 The explicit opt-out applies to the code that constructs the schedule object, which is
-not an ordinary numerical policy formula. It does not remove the schedule's unit
-contract: for every supported `look_up` or `piecewise_polynomial` call, TTSIM checks
-each input variable against the corresponding input axis and assigns the declared output
-unit to the result. The construction body is nevertheless listed as unchecked in the
-validation report.
+not a numerical policy formula. It does not remove the schedule's unit contract: for
+every supported `look_up` or `piecewise_polynomial` call, TTSIM checks each input
+variable against the corresponding input axis and assigns the declared output unit to
+the result. The construction body is nevertheless listed as unchecked in the validation
+report.
 
 A structured parameter may use `unit=UNSET_UNIT` only when the object as a whole has no
 single unit and every field that carries a quantity has its own annotation.
@@ -991,7 +992,8 @@ identifiers belong to the same domain is outside this GEP.
 
 #### Joins
 
-A supported `join` receives checks similar to a limited review of a Stata `merge`:
+A supported `join` receives limited checks, analogous to those available for a Stata
+`merge`:
 
 - the foreign and primary keys MUST have no physical unit or period;
 - the fallback used for a missing key MUST have a unit compatible with the target,
@@ -1015,7 +1017,7 @@ the checker which observations or array dimensions were combined. This is simila
 seeing a Stata total without knowing the `by()` variables.
 
 The checker therefore MUST reject these reductions inside a checked policy body instead
-of simply copying the unit of the input. A function that needs such a reduction must:
+rather than copying the unit of its input. A function that needs such a reduction must:
 
 - express it as a generated or hand-written aggregation with a declared target level; or
 - use `verify_units=False`, which the report then lists as an unchecked body.
@@ -1044,15 +1046,15 @@ lacks enough information to certify their result level.
 | rounding specification               | unit required for monetary magnitudes            | concrete currency                | function unit and statutory currency                                                             |
 | unit-annotated input                 | unit on every leaf in this mode                  | concrete source currency         | known unit, suffix period, physical measure and scale, group marker, and currency conversion     |
 
-`UNSET_UNIT` is only for a structured result that has no single unit. For ordinary
+`UNSET_UNIT` is only for a structured result that has no single unit. For all other
 parameters, functions, and aggregations, a missing unit declaration is an error.
 
 (gep-10-literals)=
 
 ### Numerical constants
 
-Multiplication and division by an ordinary numerical constant are valid. The constant
-keeps or combines with the other value's unit.
+Multiplication and division by a dimensionless numerical constant are valid. The
+constant keeps or combines with the other value's unit.
 
 ```python
 betrag_m * 0.5  # CURRENCY_PER_MONTH
@@ -1066,8 +1068,8 @@ ordered against a quantity that has a unit.
 einkommen_m < 1000.0  # Invalid: different units.
 ```
 
-A threshold with a unit should normally be stored as a policy parameter. If it must be
-written directly in the function, a local cast states its unit.
+A threshold with a unit belongs in a policy parameter. If it must be written directly in
+the function, a local cast states its unit.
 
 ```python
 einkommen_m < cast_ttsim_unit(
@@ -1138,9 +1140,9 @@ For every checked regime, environment assembly MUST verify that:
 - no input, parameter, or function introduces another currency into a policy
   calculation.
 
-This rule deliberately excludes calculations that keep DM and EUR amounts side by side
-inside one policy regime. A retroactive or carried amount that legally retains another
-currency needs a future extension; GEP 10 does not admit it silently.
+This rule excludes, by design, any calculation combining DM and EUR amounts inside one
+policy regime. A retroactive or carried amount that legally retains another currency
+needs a future extension; GEP 10 does not admit it silently.
 
 #### Parameter currency and data currency
 
@@ -1187,7 +1189,7 @@ used in the formula. Although the law may print these coefficients as plain numb
 their mathematical units can include inverse powers of currency. The unit vocabulary in
 this GEP does not represent every such coefficient.
 
-The first-stage rule is therefore:
+The rule adopted here is therefore:
 
 - evaluate the entire formula in the statutory currency of the regime;
 - keep the statutory coefficient values exactly as written; and
@@ -1234,7 +1236,7 @@ rounding.
 
 #### When checks take place
 
-| Stage                         | When                                                  | What is checked                                                                                                   |
+| Operation                     | When                                                  | What is checked                                                                                                   |
 | ----------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | declaration validation        | when a function is decorated or parameters are loaded | required declarations, valid unit names, suffixes, and permitted currencies                                       |
 | environment validation        | when a policy environment is assembled for one date   | all required units, units of automatically generated aggregations, and the statutory currency for that date       |
@@ -1244,24 +1246,24 @@ rounding.
 | numerical currency conversion | immediately before and after policy calculation       | input into statutory currency and calculated output into data currency                                            |
 
 TTSIM uses Pint only while it checks declarations and policy environments, processes
-unit-annotated input, and obtains currency conversion factors. The actual
-tax-and-transfer calculation continues to use ordinary numerical arrays, so units do not
-change the numerical representation used in a simulation.
+unit-annotated input, and obtains currency conversion factors. The tax-and-transfer
+calculation continues to use plain NumPy or JAX arrays, so units do not change the
+numerical representation used in a simulation.
 
 (gep-10-body-checker)=
 
 #### Checking policy-function calculations
 
 TTSIM calls a policy function with test values that carry the declared units of its
-arguments. It repeats the call with different decisions to examine the relevant branches
-of `if` statements and conditional expressions. Each examined return value is compared
-with the function's declaration.
+arguments. It repeats the call, taking each side of the `if` statements and conditional
+expressions in turn. Each examined return value is compared with the function's
+declaration.
 
 TTSIM knows unit rules for a defined set of operations. For each supported operation,
 its checking version MUST inspect every argument that can affect the resulting unit.
 Scalar and array-valued versions of the same calculation MUST follow equivalent rules.
 
-The checker rejects, among other things:
+The checker rejects at least:
 
 - addition, subtraction, or ordering between incompatible units;
 - a non-zero constant used as if it had a physical unit;
@@ -1283,7 +1285,7 @@ physical dimension, period, or group interpretation. In particular, it may not i
 array dimension, condition, merge key, fallback, or another argument relevant to units.
 
 The number of branches that TTSIM can examine is limited. If a function exceeds the
-documented limit on cases or branching decisions, TTSIM cannot complete the check. The
+documented limit on cases or branch conditions, TTSIM cannot complete the check. The
 author must simplify the function or use a reported opt-out.
 
 (gep-10-date-partition)=
@@ -1310,8 +1312,8 @@ rounding change is already captured by a function boundary. If a future design a
 rounding rule to change independently, its date MUST also start a new interval.
 
 `ttsim.testing_utils.get_policy_date_partition` limits these boundaries to the dates
-supported by the policy package and returns one representative date—normally the first
-date—per interval. The policy package's automated tests MUST assemble and check the
+supported by the policy package and returns one representative date per interval, by
+default the first. The policy package's automated tests MUST assemble and check the
 environment at every returned date. A parameter-only or currency-only change must start
 a new interval even when no policy function changes.
 
@@ -1377,34 +1379,34 @@ latter removes body coverage.
 
 #### Trade-offs and limitations
 
-**Different dimensionless meanings are usually not checked.** Shares, identifiers,
-category codes, counts, yes/no values, rates without a period, and ordinary scalars all
-use `DIMENSIONLESS`. TTSIM generally cannot reject calculations that confuse these
-meanings. `QuantityKind` provides only the narrow, local evidence needed for a
-dimensionless group marker; it is not a general semantic type and does not make other
-arithmetic between dimensionless values safe. For conditions, TTSIM only screens out
-values with physical units or periods; passing that screen does not establish the
-meaning of the remaining dimensionless value.
+**Different dimensionless meanings are checked only where a group marker is declared.**
+Shares, identifiers, category codes, counts, yes/no values, rates without a period, and
+other unitless scalars all use `DIMENSIONLESS`. Outside the group-marker cases above,
+TTSIM cannot reject calculations that confuse these meanings. `QuantityKind` provides
+only the narrow, local evidence needed for a dimensionless group marker; it is not a
+general semantic type and does not make other arithmetic between dimensionless values
+safe. For conditions, TTSIM only requires that the value be dimensionless; meeting that
+requirement does not establish the meaning of the remaining dimensionless value.
 
-**Equality does not compare units.** This permits useful sentinel comparisons such as
+**Equality does not compare units.** This permits sentinel comparisons such as
 `p_id_empfänger == -1`. It also means that the checker does not catch an equality
 comparison between monthly and annual income.
 
-**Group markers do not fully describe grain or validate the data layout.** They do not
-prove that rows are aligned, keys are unique, a merge has the right number of matches,
-or an identifier belongs to a particular domain. For example, a household's housing-cost
-share uses `DIMENSIONLESS`, not `DIMENSIONLESS_PER_HH`: the share has no physical
-household denominator, even though it varies across households. The group marker records
-selected group totals, counts, and indicators, not simply the level at which a variable
-is observed.
+**Group markers do not fully describe the level or validate the data layout.** They do
+not prove that rows are aligned, keys are unique, a merge has the right number of
+matches, or an identifier belongs to a particular domain. For example, a household's
+housing-cost share uses `DIMENSIONLESS`, not `DIMENSIONLESS_PER_HH`: the share has no
+physical household denominator, even though it varies across households. The group
+marker records selected group totals, counts, and indicators, not the level at which a
+variable is observed.
 
 **Only selected group calculations are supported.** TTSIM checks the head-count
 conversions, scalar changes, logical rules, and generated aggregations stated above.
 Other products or ratios involving group-marked values need a local assertion or an
 opt-out.
 
-**Branch checking has a limit.** A body that exceeds the limit on cases or branching
-decisions is not silently accepted.
+**Branch checking has a limit.** A body that exceeds the limit on cases or branch
+conditions is not silently accepted.
 
 **Some operations remain unsupported.** Raw array reductions are rejected. Joins receive
 only the unit checks described above; they do not show that the keys identify the same
@@ -1434,8 +1436,7 @@ hide an error. Casts must remain local and appear in the validation report.
 #### Explicit exceptions
 
 `cast_ttsim_unit(value, unit=unit)` tells the body checker to treat one expression as
-having the stated unit. During the actual numerical calculation, it returns `value`
-unchanged.
+having the stated unit. During the numerical calculation, it returns `value` unchanged.
 
 A cast is appropriate for:
 
@@ -1495,14 +1496,14 @@ An implementation conforms to this GEP only if all of the following hold:
 1. validation output reports declarations, checked bodies, generated rules, casts,
    whole-body opt-outs, and every other unchecked body separately.
 
-Passing the ordinary project tests is not enough to demonstrate these requirements. The
-implementation tests SHOULD deliberately introduce a mistake for every rule. Examples
-include returning a stock where a flow is declared, using money as a condition, passing
-an invalid condition to `xnp.where`, using a fallback with the wrong unit in a join,
-marking a share as a group total, letting a count axis authorize a rent-class axis,
-letting one nested occurrence authorize another occurrence of the same dataclass type,
-treating a group mean as person-level, and omitting a date on which only a parameter or
-currency changes.
+Passing the project's existing tests is not enough to demonstrate these requirements.
+The implementation tests SHOULD deliberately introduce a mistake for every rule.
+Examples include returning a stock where a flow is declared, using money as a condition,
+passing an invalid condition to `xnp.where`, using a fallback with the wrong unit in a
+join, marking a share as a group total, letting a count axis authorize a rent-class
+axis, letting one nested occurrence authorize another occurrence of the same dataclass
+type, treating a group mean as person-level, and omitting a date on which only a
+parameter or currency changes.
 
 ## Related work
 
@@ -1514,7 +1515,7 @@ currency changes.
 - {ref}`GEP 9 <gep-9>` defines checks of values supplied when the model runs and their
   conversion to the standard internal data format.
 - [Pint](https://pint.readthedocs.io) supplies the physical-unit definitions and
-  ordinary unit arithmetic.
+  dimensional arithmetic.
 - [GETTSIM #1205](https://github.com/ttsim-dev/gettsim/issues/1205) tracks legally
   sensitive reference-period conventions.
 - [GETTSIM #1219](https://github.com/ttsim-dev/gettsim/issues/1219) records the review
@@ -1556,31 +1557,31 @@ requirements added by this revision:
 
 ## Alternatives
 
-### A broader system for units, data grain, and economic meaning
+### A broader system for units, data levels, and economic meaning
 
 Deferred. A broader design could separately record the physical unit, economic meaning,
-grain, kind of identifier, whether a value is a total or intensive measure, array
+level, kind of identifier, whether a value is a total or intensive measure, array
 dimensions, calendar meaning, currency history, and missing-value rules. It could then
 check more merge operations, row alignment, group-specific shares, and coefficients with
 inverse units.
 
-Such a system would be much larger than the unit checks needed for the current GETTSIM
-and METTSIM rollout. This GEP therefore focuses on physical units, periods, and selected
-group calculations. It rejects an operation when accepting it would give a misleading
-impression of coverage. A later GEP may add checks of data relations or economic meaning
-without changing the physical-unit rules here.
+Such a system would require every record listed above, well beyond the unit checks
+needed to adopt units in GETTSIM and METTSIM. This GEP therefore focuses on physical
+units, periods, and selected group calculations. It rejects an operation when accepting
+it would give a misleading impression of coverage. A later GEP may add checks of data
+relations or economic meaning without changing the physical-unit rules here.
 
 ### A separate public unit for shares or identifiers
 
-Deferred. Pint correctly treats shares and identifiers as having no physical unit. A
-useful distinction between them would therefore require additional rules beyond Pint.
-This GEP keeps the public unit vocabulary small, documents what remains unchecked, and
-adds only the condition and group-declaration rules needed for its stated guarantees.
+Deferred. Pint correctly treats shares and identifiers as having no physical unit.
+Distinguishing them would therefore require additional rules beyond Pint. This GEP keeps
+the public unit vocabulary small, documents what remains unchecked, and adds only the
+condition and group-declaration rules needed for its stated guarantees.
 
-### A complete model of data grain
+### A complete model of data levels
 
 Deferred. The group markers in this GEP support selected arithmetic; they are not a
-complete model of data grain and are not types for rows or merge keys. The kind and
+complete model of data levels and are not types for rows or merge keys. The kind and
 uniqueness of identifiers, the number of merge matches, automatic repetition across rows
 or array dimensions, and row alignment remain outside scope. A reduction that would
 require such information is rejected instead of being assigned an unchanged unit.
@@ -1590,7 +1591,7 @@ require such information is rejected instead of being assigned an unchanged unit
 Rejected for this proposal. Earlier designs wrote every person amount as
 `... / [person]` and every group head count as `[person] / [group]`. This made the
 person level explicit but added a component to almost every declaration and allowed two
-ways to write the same practical person quantity.
+ways to write the same person-level quantity.
 
 The adopted design leaves person quantities without a group denominator and writes a
 group head count as `1 / [group]`. After dividing a group total by its head count, TTSIM
@@ -1609,14 +1610,15 @@ calculated output at the boundary.
 
 Rejected. `pint.Quantity` is not part of the intended NumPy/JAX numerical data. Units
 are checked while a policy environment is assembled and at its input and output
-boundaries. The actual tax-and-transfer calculation continues to receive ordinary
-numbers and arrays.
+boundaries. The tax-and-transfer calculation continues to receive plain numbers and
+NumPy or JAX arrays.
 
 ### Remove concrete currencies from parameter declarations
 
 Rejected. Because each regime uses one statutory currency, concrete labels may appear
-redundant. They are nevertheless valuable checks and documentation. A Euro parameter
-used in a Deutsche-Mark regime should produce an immediate error.
+redundant. They nevertheless document the denomination in the file and catch a mismatch
+with the regime. A Euro parameter used in a Deutsche-Mark regime should produce an
+immediate error.
 
 ## Discussion
 

--- a/docs/geps/gep-10.md
+++ b/docs/geps/gep-10.md
@@ -1,6 +1,6 @@
 (gep-10)=
 
-# GEP 10 — Units and Dimensionality
+# GEP 10 — Value Types, Units, Grain, and Currency
 
 ```{list-table}
 - * Author
@@ -17,46 +17,105 @@
 
 ## Abstract
 
-This GEP introduces explicit units for all nodes in GETTSIM. A unit records what a value
-measures, its reference period, and, where relevant, the group to which it belongs.
-Examples are Euros per month or square meters per household.
+This GEP introduces a static value-type system for every node, parameter, input,
+generated operation, and result in TTSIM and GETTSIM. A value type records several
+independent facts:
 
-These declarations allow GETTSIM to detect whether a policy function actually computes
-the quantity it claims to compute and helps to detect inconsistent calculations before a
-simulation is run. For example, GETTSIM will reject operations that add a monthly euro
-amount to a yearly euro amount or add a household total to a Bedarfsgemeinschaft total
-without an explicit conversion.
+1. its physical unit;
+1. its policy reference-period signature and conversion convention;
+1. its semantic kind, such as number, boolean, share, count, identifier, or category;
+1. the entity the value describes and the row domain on which it is represented;
+1. any additional named tensor axes;
+1. whether the value is extensive, intensive, statistic-derived, or a neutral modifier;
+1. any calendar-point, duration, or ordinal semantics;
+1. its currency denomination and provenance; and
+1. whether it may be missing.
 
-Unit declarations also make historical currency handling explicit. GETTSIM calculates a
-policy using the currency in which the applicable law specifies its parameters. Users
-supply monetary data and request computed results in either Deutsche Mark or Euro, while
-statutory parameter values remain unchanged.
+These axes are deliberately not collapsed into one Pint expression. Pint is responsible
+only for physical-unit algebra and physical conversion. Policy periods, grouping levels,
+identifiers, booleans, counts, storage grain, tensor axes, calendar ordinals, extensity,
+and currency provenance are separate type components with separate rules.
+
+TTSIM validates declarations, graph edges, supported policy-function bodies, joins,
+aggregations, reductions, schedules, date regimes, rounding rules, and typed data
+boundaries. The body checker is a conservative abstract interpreter over a documented
+Python subset. It is not described as executing a proof of arbitrary Python. Every
+active node and date regime receives an auditable evidence status, and every assertion
+or exemption is reported separately from verified code.
+
+For historical currencies, each policy regime is evaluated in the statutory denomination
+in which its parameters and coefficients are written. Input and output conversion occurs
+at explicit boundaries. Coefficients with inverse-currency or period units declare those
+units; statutory-currency evaluation is not a substitute for dimensional correctness.
+
+## Normative language
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**,
+**SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **NOT RECOMMENDED**, **MAY**, and
+**OPTIONAL** in this document are to be interpreted as described in
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and
+[RFC 8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in
+capital letters.
 
 ## Motivation and scope
 
-Four problems motivate this GEP.
+TTSIM policy code currently manipulates ordinary Python, NumPy, and JAX values. Runtime
+dtypes can distinguish integers, floating-point numbers, and booleans, but they cannot
+by themselves distinguish monthly income from wealth, a household total from a person
+amount, a household ID from a tax-unit ID, a calendar year from an age, or a share from
+a count.
 
-1. **Arithmetic is not dimensionally validated.** GETTSIM currently treats values with
-   different meanings as ordinary numbers. A calculation can therefore add a total
-   amount of rent to rent per square meter without failing immediately.
-1. **Grouping levels are not part of arithmetic validation.** A household total and a
-   Bedarfsgemeinschaft total can be combined without an explicit conversion. A missing
-   division by the number of people in a group is also not detected.
-1. **Historical currencies are represented inconsistently.** Some historical monetary
-   parameters retain their statutory Deutsche-Mark values, while others are stored as
-   mechanically converted Euro values with the original amount recorded only in
-   free-text metadata. However, storing DM values in their converted Euro form violates
-   GETTSIM's law-to-code principle.
-1. **Reference-period conversion factors are maintained separately.** GETTSIM already
-   converts between annual, quarterly, monthly, weekly, and daily values. The numerical
-   ratios for those conversions should come from the same unit system that validates
-   policy calculations.
+A reliable validation system must address six independent problem classes.
 
-The GEP covers the unit infrastructure in TTSIM and the currency and policy declarations
-in GETTSIM. It treats Deutsche Mark and Euros as the currency space.
+1. **Physical and period consistency.** Arithmetic must reject incompatible physical
+   measures and incompatible policy reference periods. A stock of wealth must not
+   silently become a monthly flow. Rent per square meter must not be added to total
+   rent.
+1. **Semantic-kind consistency.** A boolean, identifier, category, share, probability,
+   rate, count, and unrestricted number are not interchangeable merely because each can
+   be stored in an integer or floating-point array.
+1. **Relational, grain, and axis consistency.** Group membership, keys, row domains,
+   broadcast values, joins, cardinality, aggregation, and local tensor axes are
+   structural properties. They are not physical dimensions and must not be represented
+   as Pint denominators.
+1. **Extensity consistency.** Sums, means, extrema, counts, and per-capita
+   transformations have different semantics. A mean remains a statistic of the target
+   group; it does not become a person-level value because a symbolic group denominator
+   happened to cancel.
+1. **Calendar consistency.** Absolute dates, year points, year-month points, durations,
+   month-of-year ordinals, and day-of-month ordinals support different operations. In
+   particular, February and the fifteenth day are not context-free affine points.
+1. **Currency and provenance consistency.** A monetary value has a physical currency
+   dimension, a denomination, an origin or effective-date rule, and an ordering relative
+   to statutory rounding. Historical statutory coefficients may have inverse-currency
+   units even when the law prints them as bare numbers.
 
-Notably, the naming conventions defined in {ref}`GEP 1 <gep-1>` (group and time
-suffixes) and their automatic conversion remain in effect.
+This GEP covers:
+
+- the canonical static type of scalar and array leaves, plus compound structure and
+  mapping types;
+- declarations on policy functions, policy inputs, parameters, structured values,
+  schedules, rounding specifications, generated nodes, and typed data;
+- type rules for supported scalar and vectorized expressions;
+- relational operations, including joins, gathers, broadcasts, allocations, and
+  aggregations;
+- policy reference-period conversion;
+- calendar types and operations;
+- statutory and data currency handling;
+- validation over every distinct policy-date regime;
+- evidence, coverage, exceptions, and conformance requirements; and
+- the migration of TTSIM, METTSIM, and GETTSIM.
+
+The GEP does **not** claim to prove that a policy formula implements the law, that a
+numerical algorithm is stable, that values are finite, or that arbitrary Python is safe.
+It provides a sound static contract for the documented expression language and explicit
+evidence for the parts it cannot verify.
+
+The naming conventions and generated period conversions in {ref}`GEP 1 <gep-1>`,
+grouping and identifier declarations in {ref}`GEP 2 <gep-2>`, DAG and aggregation
+concepts in {ref}`GEP 4 <gep-4>`, rounding in {ref}`GEP 5 <gep-5>`, and runtime
+user/canonical type split in {ref}`GEP 9 <gep-9>` remain in force except where this GEP
+explicitly refines them.
 
 (gep-10-usage)=
 
@@ -64,943 +123,2559 @@ suffixes) and their automatic conversion remain in effect.
 
 ### Users of existing policy environments
 
-Most users continue to call `main()` with ordinary arrays or a DataFrame. Users may
-provide a `data_currency` argument to specify the currency of their monetary input and
-the desired currency of computed results. The default is Euro. Data currency may be one
-of two registered currencies: `EUR` or `DM`.
+Users may continue to call `main()` with ordinary arrays, mappings, or a DataFrame.
+Untyped data remain supported, but the resulting evidence report records that their
+non-dtype semantics were **assumed from the policy node**, not independently verified
+from the input.
+
+A user may select the denomination of untyped monetary input and computed output with
+`data_currency`. The default for GETTSIM remains Euro.
 
 ```python
 results = main(
     policy_date_str="1999-01-01",
+    data_currency="EUR",
     # Other arguments omitted.
 )
 ```
 
 For this run, GETTSIM:
 
-1. converts currency-denominated input columns and scalar input values from Euro to
-   Deutsche Mark;
-1. evaluates the 1999 policy in Deutsche Mark using the statutory parameters; and
-1. converts computed currency-denominated results back to Euro.
+1. resolves the 1999 policy environment and its complete value types;
+1. converts monetary input from Euro to the statutory 1999 denomination;
+1. evaluates the policy using statutory parameters and coefficients without rewriting
+   their legal numerical values;
+1. applies statutory rounding in the concrete denomination declared by each rounding
+   rule; and
+1. converts computed monetary results to Euro after statutory computation is complete.
 
-Input columns without a currency component, requested parameters, and requested input
-columns are not converted on output.
+Requested raw inputs are returned unchanged. Requested parameters retain their statutory
+currency and provenance unless the caller explicitly asks for a converted presentation
+value.
 
 (gep-10-trees)=
 
-### Unit-annotated data
+### Fully typed input and output
 
-Input unit annotations are optional. They are useful when users want GETTSIM to validate
-the units of their data in addition to converting its currency. When this input mode is
-selected, every leaf must be a `UnitAnnotatedColumn`, including identifiers and
-dimensionless columns. A `UnitAnnotatedColumn` pairs ordinary column values, such as a
-list, NumPy or JAX array, or pandas Series, with their unit. For example, a Series can
-be wrapped as `UnitAnnotatedColumn(values=series, unit=TTSIMUnit.EUR.PER_MONTH)`.
-Numerical and plotting libraries receive the wrapper's `.values`.
+Users who want the input boundary checked may wrap every leaf in `TypedColumn`. The
+wrapper contains ordinary values and a complete source `ValueSpec`.
 
 ```python
 from gettsim import InputData, MainTarget, TTTargets, main
-from gettsim.tt import TTSIMUnit, UnitAnnotatedColumn
+from gettsim.tt import Entity, Extensity, Index, Key, Period, Q, TypedColumn
 
 input_tree = {
-    "p_id": UnitAnnotatedColumn(values=[0, 1], unit=TTSIMUnit.DIMENSIONLESS),
-    "bg_id": UnitAnnotatedColumn(values=[0, 0], unit=TTSIMUnit.DIMENSIONLESS),
-    "geburtsjahr": UnitAnnotatedColumn(
-        values=[1980, 2015],
-        unit=TTSIMUnit.CALENDAR_YEAR,
+    "p_id": TypedColumn(
+        values=[0, 1],
+        value_type=Q.identifier(Key.P_ID),
     ),
-    "einkommen_m": UnitAnnotatedColumn(
+    "bg_id": TypedColumn(
+        values=[0, 0],
+        value_type=Q.identifier(Key.BG_ID),
+    ),
+    "geburtsjahr": TypedColumn(
+        values=[1980, 2015],
+        value_type=Q.calendar_year_point(
+            subject=Entity.PERSON,
+            index=Index.unique(Entity.PERSON),
+        ),
+    ),
+    "einkommen_m": TypedColumn(
         values=[2000.0, 0.0],
-        unit=TTSIMUnit.EUR.PER_MONTH,
+        value_type=Q.money(
+            period=Period.per_month(),
+            subject=Entity.PERSON,
+            extensity=Extensity.EXTENSIVE,
+            currency="EUR",
+            index=Index.unique(Entity.PERSON),
+        ),
     ),
 }
 
 results = main(
-    main_target=MainTarget.results.tree_with_unit_annotations,
+    main_target=MainTarget.results.tree_with_value_types,
     policy_date_str="2025-01-01",
-    input_data=InputData.tree_with_unit_annotations(input_tree),
+    input_data=InputData.tree_with_value_types(input_tree),
     tt_targets=TTTargets(tree={"transfer": {"betrag_m": None}}),
 )
 ```
 
-The unit tag's physical dimension, period, and grouping level must agree with the
-declaration of the corresponding input in GETTSIM's DAG. Only the currency may differ,
-in which case the value is converted.
+The boundary requires exact agreement on semantic kind, subject, extensity, calendar
+semantics, key domain, and compatible index and local-axis representation. Physical
+units and period specifications must be compatible or connected by registered
+conversions. A concrete input currency may differ from the computation currency and is
+converted at the boundary. A key domain, boolean kind, category domain, or subject grain
+is never converted.
 
-For unit-annotated input, each leaf's concrete currency tag determines its source
-currency. `data_currency` determines the currency assumed for unannotated monetary input
-and the currency of computed results.
+`MainTarget.results.tree_with_value_types` returns each computed leaf as a `TypedColumn`
+with the fully resolved value type and concrete output denomination. Ordinary result
+targets continue to return bare values.
 
-When `MainTarget.results.tree_with_unit_annotations` is requested, the result tree has
-the same structure as `MainTarget.results.tree`, but its computed leaves carry unit
-annotations. Request `MainTarget.results.tree` instead to receive the same tree with
-ordinary values. Computed currency values are tagged with the concrete data currency,
-while requested parameters retain their statutory currency.
+### Contributors: policy functions and inputs
 
-### Contributors and users extending policy environments
-
-Contributors and users adding functions to a policy environment must declare units on
-policy functions, policy inputs, parameters, rounding specifications, and hand-written
-aggregations.
-
-#### Policy functions
-
-A policy function declares the unit of its return value. TTSIM validates the function
-body against that declaration when the policy environment is checked.
-
-The following function declares the unit `CURRENCY_PER_MONTH_PER_BG`, which means
-currency per month and per Bedarfsgemeinschaft. Policy functions declare the abstract
-`CURRENCY` base rather than `EUR` or `DM`. TTSIM replaces it with the statutory currency
-for the selected policy date. All other unit components, such as the period and grouping
-level, remain explicit.
+A policy function declares a `value_type`, not a single compositional unit token.
 
 ```python
-@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_BG)
-def regelsatz_m_bg(...) -> float: ...
+from ttsim.tt import Entity, Extensity, Period, Q
 
-@policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_BG)
-def mehrbedarf_m_bg(...) -> float: ...
 
-@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_BG)
+@policy_input(
+    value_type=Q.money(
+        period=Period.per_month(),
+        subject=Entity.BG,
+        extensity=Extensity.EXTENSIVE,
+    )
+)
+def regelsatz_m_bg() -> float: ...
+
+
+@policy_input(
+    value_type=Q.money(
+        period=Period.per_month(),
+        subject=Entity.BG,
+        extensity=Extensity.EXTENSIVE,
+    )
+)
+def mehrbedarf_m_bg() -> float: ...
+
+
+@policy_function(
+    value_type=Q.money(
+        period=Period.per_month(),
+        subject=Entity.BG,
+        extensity=Extensity.EXTENSIVE,
+    )
+)
 def betrag_m_bg(regelsatz_m_bg: float, mehrbedarf_m_bg: float) -> float:
     return regelsatz_m_bg + mehrbedarf_m_bg
 ```
 
-The declaration means currency per month and Bedarfsgemeinschaft. The `_m` suffix must
-agree with `PER_MONTH`. The operation is valid because both operands have the same unit.
-The result is also `CURRENCY_PER_MONTH_PER_BG`.
+`Q.money()` uses the abstract `STATUTORY` currency in code-side declarations. At a
+policy date, the policy environment resolves it to the concrete statutory denomination.
+The `_m` suffix must agree with the period signature, and `_bg` must agree with the
+declared subject where GEP 1 says the suffix denotes the subject. Suffixes are
+consistency checks; they do not supply missing type axes and do not encode storage
+layout.
 
-The following function is rejected because its operands have different physical units:
-
-```python
-@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
-def amount_m(...) -> float: ...
-
-@policy_input(unit=TTSIMUnit.CURRENCY.PER_SQUARE_METER.PER_MONTH)
-def rent_per_square_meter_m(...) -> float: ...
-
-@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
-def incorrect_amount_m(
-    amount_m: float,
-    rent_per_square_meter_m: float,
-) -> float:
-    return amount_m + rent_per_square_meter_m
-```
-
-**Opting out of unit validation.**
-
-Sometimes, policy functions perform correct operations that also violate unit
-arithmetic, e.g. cross-level operations (sum a HH and BG amount). In these cases, users
-can either
-
-1. opt out of unit validation for the entire policy function by setting
-   `verify_units=False` in the decorator, or
-1. use `cast_ttsim_unit` to explicitly assign the expected unit to one expression.
-
-For example, the following function is valid because it explicitly asserts that
-`amount_m_bg` has unit `CURRENCY_PER_MONTH_PER_HH` before adding it to `amount_m_hh`.
+Booleans are declared as booleans, not as dimensionless numbers.
 
 ```python
-@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_HH)
-def amount_m_hh(...) -> float: ...
+@policy_input(value_type=Q.boolean(subject=Entity.PERSON))
+def eligible() -> bool: ...
 
-@policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_BG)
-def amount_m_bg(...) -> float: ...
 
-@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_HH)
-def correct_amount_m(
-    amount_m_hh: float,
-    amount_m_bg: float,
-) -> float:
-    return amount_m_hh + cast_ttsim_unit(
-        value=amount_m_bg,
-        unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_HH,
+@policy_function(
+    value_type=Q.money(
+        period=Period.per_month(),
+        subject=Entity.PERSON,
+        extensity=Extensity.EXTENSIVE,
     )
+)
+def transfer_m(eligible: bool, amount_m: float) -> float:
+    return amount_m if eligible else 0
 ```
 
-#### Parameters
+The condition is checked as `BOOLEAN`. The zero arm is a typed zero literal that adopts
+the type of `amount_m`. A currency value, ID, count, or category used directly as the
+condition is an error in both scalar and vectorized code.
 
-Parameter files record the currency and period in which the statute specifies a value.
+### Contributors: explicit group operations
+
+Grouping is expressed through typed relations rather than physical-unit denominators.
+
+```python
+rent_m_hh = aggregate(
+    rent_m_person,
+    relation=PERSON_TO_HH,
+    how=SUM,
+)
+
+average_rent_m_hh = mean_per_member(
+    rent_m_hh,
+    count=persons_in_hh,
+    relation=PERSON_TO_HH,
+)
+
+rent_allocation_m_person = allocate_equal(
+    rent_m_hh,
+    count=persons_in_hh,
+    relation=PERSON_TO_HH,
+)
+```
+
+`rent_m_hh` is an extensive monthly monetary amount with subject `HH`.
+`average_rent_m_hh` is an intensive “per member” statistic that remains a property of
+the household and is stored once per household. `rent_allocation_m_person` is an
+extensive person amount whose allocations sum back to the household total. All three
+retain the physical currency unit and monthly period. No `[hh]` dimension is created or
+cancelled, and storage grain is not confused with allocation incidence.
+
+A group value aligned to person rows is produced by a typed gather or broadcast.
+
+```python
+allowance_m_person = gather(
+    foreign_key=hh_id,
+    primary_key=hh_table_id,
+    target=allowance_m_hh,
+    cardinality=MANY_TO_ONE,
+    on_missing=MISSING,
+)
+```
+
+The key domains, primary-key uniqueness, declared cardinality, missing policy, target
+type, and source and target row domains are validated. A monetary value cannot be used
+as a key, and an `Id[HH]` cannot be joined to an `Id[BG]`.
+
+### Contributors: coefficients with inverse units
+
+Statutory evaluation in a concrete currency does not make fitted or statutory
+coefficients dimensionless. Coefficients declare their complete mathematical type.
 
 ```yaml
-einkommensgrenze_m:
-  unit: EUR_PER_MONTH
-  type: scalar
+wohngeld_coefficients:
+  type: dict
+  value_type:
+    a:
+      unit: one
+      period: stock
+      kind: number
+      subject: global
+      extensity: neutral
+    b:
+      unit: 1 / currency
+      period: month
+      kind: number
+      subject: global
+      extensity: neutral
+      currency: EUR
+    c:
+      unit: 1 / currency ** 2
+      period: month ** 2
+      kind: number
+      subject: global
+      extensity: neutral
+      currency: EUR
   2024-01-01:
-    value: 1000.0
+    a: 0.04
+    b: 0.0002
+    c: 0.0001
 ```
 
-Currency-denominated parameters must use a concrete currency. A build-time check
-requires that currency to equal the statutory currency at the parameter's policy date.
+Multiplying `b` by an `EUR_PER_MONTH` income, or `c` by the square of that income,
+produces a dimensionless number. Declaring either coefficient as a bare dimensionless
+number is rejected. A later statutory-currency regime supplies new dated coefficient
+values and matching concrete currency declarations.
 
 ## Backward compatibility
 
-- Bare arrays and the DataFrame/mapper input interface remain supported.
-- `data_currency` defaults to `EUR` in GETTSIM, so current-policy Euro inputs and
-  outputs retain their existing denomination.
-- The former `reference_period` and `reference_level` fields are removed. Their
-  information becomes part of the compositional unit, for example `EUR_PER_YEAR_PER_FG`.
-- Existing policy functions, policy inputs, parameter files, and hand-written
-  aggregations require unit declarations.
-- Unit validation cannot be disabled globally. `verify_units=False` disables body
-  validation for one function. Setting `include_fail_nodes=False` in `main()` skips unit
-  checks performed while assembling the policy environment and processing annotated
-  input, but malformed declarations are still rejected.
+This GEP deliberately replaces the one-dimensional compositional-unit model.
+
+- Bare arrays and the DataFrame or mapping interfaces remain supported. Their semantic
+  types are assumed from the policy environment and reported as unverified input
+  assumptions.
+- `data_currency` continues to default to `EUR` in GETTSIM.
+- The legacy `unit=` decorator argument and `TTSIMUnit` builder MAY be supported for one
+  deprecation cycle as a migration adapter. The adapter may recover only the physical
+  unit and a simple standard reference-period signature where that mapping is
+  unambiguous. It MUST NOT infer a period convention, semantic kind, subject, extensity,
+  key or category domain, row index, local tensor axes, calendar semantics, currency
+  provenance, or nullability from a grouping denominator, suffix, runtime dtype, or
+  example value.
+- `PER_HH`, `PER_BG`, and other group suffixes are removed from physical-unit syntax.
+  Grouping is represented by `subject`, `index`, relations, and aggregation metadata.
+- `DIMENSIONLESS` is no longer a sufficient declaration. Contributors must declare
+  whether a value is a number, boolean, share, probability, rate, count, identifier, or
+  category.
+- `verify_units=False` is removed. A whole-body exemption requires a structured
+  `ValidationExemption` and remains visibly unverified.
+- `cast_ttsim_unit` is deprecated. Dimensioned literals, alignment, semantic
+  reassignment, and last-resort type assertions use separate operations with structured
+  justification.
+- Existing functions, policy inputs, parameters, schedules, structured fields, rounding
+  rules, joins, hand-written aggregations, and generated nodes require complete resolved
+  value types before a policy package can claim conformance.
+- Naming suffixes remain mandatory where required by GEP 1, but they are consistency
+  checks and never the sole source of a value type.
+
+A project MAY stage migration behind a compatibility flag, but it MUST NOT describe a
+legacy adapter result as body-verified or fully typed unless every canonical axis has
+been resolved and validated.
 
 ## Detailed description
 
+(gep-10-principles)=
+
+### Design principles
+
+The implementation MUST follow these principles.
+
+1. **Independent facts use independent type axes.** A household is an entity domain, not
+   a physical denominator. A boolean is a semantic kind, not a dimensionless number.
+   February is a calendar ordinal, not an affine month point.
+1. **The canonical type is explicit.** Convenience constructors may fill documented
+   defaults, but every active leaf is resolved to a complete `ValueSpec` and every
+   compound producer to a complete `TypeSpec` before validation.
+1. **Operations are conservative.** An operation without a registered type rule fails.
+   It does not silently preserve the input type, discard an argument, or fall back to a
+   generic dimensionless result.
+1. **Scalar and vectorized code share one rule table.** Python operators, `xnp`
+   operations, and generated graph operations call the same type-rule implementation.
+1. **Relational transformations are explicit.** Broadcast, gather, join, aggregation,
+   deduplication, allocation, and per-capita transformations carry relation and
+   cardinality metadata.
+1. **Assertions are evidence, not verification.** A type assertion or whole-body
+   exemption is reported as such and cannot raise verified-body coverage.
+1. **All policy regimes are checked.** Validation uses the maximal date partition
+   induced by functions, parameters, schemas, units, currencies, rounding rules, and
+   generated nodes.
+1. **Registries are environment-local.** Currencies, entities, categories, keys,
+   primitive signatures, and period systems belong to an immutable `UnitSystem` or
+   policy environment. Process-global mutation is not part of the correctness contract.
+1. **Claims match evidence.** TTSIM may claim sound checking only for the documented
+   expression subset. Unsupported or exempt code remains visible in the evidence report.
+
+(gep-10-guarantee)=
+
+(gep-10-limitations)=
+
+### Validation guarantee and claim vocabulary
+
+For a node marked `BODY_VERIFIED`, the implementation guarantees the following,
+conditional on its stated trust boundary: if typed inputs satisfy their declared
+contracts, registered relations and primitive signatures are correct, and execution
+stays within the supported language, then every syntactic execution path is type safe
+under this GEP and every return is compatible with the declared result `TypeSpec`. “Type
+safe” means that no operation violates the physical, period, semantic-kind, subject,
+index, local-axis, extensity, calendar, currency, or nullability rules.
+
+This guarantee is deliberately conditional. It does not prove that:
+
+- the formula implements the statute or an economic model correctly;
+- an asserted relation is true of malformed runtime data unless its value constraints
+  are checked;
+- a result lies in an economically valid range;
+- floating-point evaluation is stable or finite;
+- an external primitive's implementation matches its registered signature; or
+- code outside the supported language has been analyzed.
+
+The public claim vocabulary is normative.
+
+| Claim                 | Minimum evidence                                                                                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type-resolved package | every active leaf and interval has a complete `ValueSpec`; no `UNRESOLVED_TYPE`                                                                                     |
+| body-verified package | every ordinary body is `BODY_VERIFIED`; every generated node is `DERIVED_BY_GENERATED_RULE`; trusted external primitives are enumerated                             |
+| boundary-verified run | the package is body verified and every supplied input leaf is independently typed and validated                                                                     |
+| GEP-10 fully verified | body-verified package, complete maximal date partition, no body exemptions, no `TYPE_ASSERTION_USED` qualifier, and a boundary-verified run for the claimed dataset |
+
+A package using untyped input may be body verified, but the run is not boundary
+verified. A package containing a reviewed body exemption may be type resolved, but it is
+not body verified or fully verified. User interfaces and release notes MUST use these
+terms or equally precise terms; they MUST NOT collapse them into “unit checked.”
+
+(gep-10-terminology)=
+
 ### Terminology
 
-| Term               | Meaning                                                                                                 |
-| ------------------ | ------------------------------------------------------------------------------------------------------- |
-| quantity           | A value with a declared unit, such as an income, age, share, or head count.                             |
-| base               | The numerator of a compositional unit, such as `CURRENCY`, `DIMENSIONLESS`, or `YEARS`.                 |
-| period             | The denominator that distinguishes a flow from a stock, such as `MONTH` or `YEAR`.                      |
-| grouping level     | The entity to which a group property belongs, such as a household (`hh`) or Bedarfsgemeinschaft (`bg`). |
-| bare               | A quantity without a grouping-level denominator. Personal quantities are bare.                          |
-| stock              | A quantity without a period denominator, such as wealth or an age.                                      |
-| flow               | A quantity with a period denominator, such as income per month.                                         |
-| statutory currency | The currency in which the applicable statute specifies monetary amounts at a policy date.               |
-| data currency      | The currency of user-provided monetary columns and returned computed results.                           |
+| Term                  | Meaning                                                                                                                                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| physical unit         | Algebraic measure handled by Pint, such as currency, square meters, hectares, or working hours.                                                                                                                |
+| period specification  | Symbolic policy reference-period factor plus the convention and provenance governing conversion, such as a standard annualized month or an actual-day statutory rule. It is distinct from calendar duration.   |
+| semantic kind         | Meaning that is not captured by physical units, such as boolean, share, count, identifier, or category.                                                                                                        |
+| subject               | Entity the value describes, such as a person, household, or tax unit.                                                                                                                                          |
+| index                 | Relational row domain and representation on which a value is stored or evaluated.                                                                                                                              |
+| local axis            | Named non-row tensor dimension, such as choice, coefficient order, or stochastic node, with a typed coordinate and reduction contract.                                                                         |
+| extensity             | Whether values add over disjoint subject entities (`EXTENSIVE`), are pointwise nonadditive (`INTENSIVE`), are reducer-selected statistics (`STATISTIC`), or act as neutral constants or modifiers (`NEUTRAL`). |
+| relation              | Typed mapping between entity domains, including key domains and cardinality.                                                                                                                                   |
+| calendar point        | A coordinate on an affine calendar axis, such as a year or absolute date.                                                                                                                                      |
+| calendar ordinal      | A cyclic or contextual coordinate, such as month of year or day of month.                                                                                                                                      |
+| calendar duration     | A displacement on a calendar axis, such as years or days.                                                                                                                                                      |
+| statutory currency    | Concrete denomination in which the applicable law writes monetary parameters and coefficients.                                                                                                                 |
+| data currency         | Concrete denomination of user-provided monetary data or requested computed results.                                                                                                                            |
+| currency provenance   | Rule identifying where a denomination comes from and which effective date controls it.                                                                                                                         |
+| verification evidence | Machine-readable record of how a node's type was obtained and what was checked.                                                                                                                                |
+| assertion             | Explicit refinement of unresolved or deliberately broad type information that the checker cannot derive; it cannot overwrite a known conflicting type.                                                         |
+| exemption             | Structured decision not to body-check a function. Its declared result remains a consumer contract but is not verified.                                                                                         |
+
+(gep-10-valuespec)=
 
 (gep-10-vocabulary)=
 
-### Compositional unit vocabulary
-
-A unit consists of one base followed by at most one denominator of each category. The
-categories have a fixed order.
-
-```text
-base        := CURRENCY
-             | EUR | DM
-             | DIMENSIONLESS
-             | HOURS
-             | SQUARE_METER | HECTARE
-             | YEARS | QUARTERS | MONTHS | DAYS
-             | CALENDAR_YEAR | CALENDAR_QUARTER | CALENDAR_MONTH | CALENDAR_DAY
-
-physical    := SQUARE_METER | HOURS
-period      := MONTH | YEAR | QUARTER | WEEK | DAY
-level       := HH | BG | FG | SN | ...
-
-unit        := base
-             | base _PER_ physical
-             | base _PER_ period
-             | base _PER_ level
-             | base _PER_ physical _PER_ period
-             | base _PER_ physical _PER_ level
-             | base _PER_ period _PER_ level
-             | base _PER_ physical _PER_ period _PER_ level
-```
-
-Each denominator category may appear at most once and must follow the order shown above.
-For example, `EUR_PER_MONTH_PER_YEAR` is invalid; use either `EUR_PER_MONTH` or
-`EUR_PER_YEAR`. `EUR_PER_BG_PER_MONTH` is also invalid; the correctly ordered
-declaration is `EUR_PER_MONTH_PER_BG`.
-
-In Python code, units are constructed by chaining attributes, for example
-`TTSIMUnit.CURRENCY.PER_MONTH.PER_BG`. The builder rejects repeated components and
-components added in the wrong order.
-
-```python
-TTSIMUnit.CURRENCY.PER_MONTH.PER_BG
-TTSIMUnit.CURRENCY
-TTSIMUnit.DIMENSIONLESS
-TTSIMUnit.DIMENSIONLESS.PER_FG
-TTSIMUnit.HOURS.PER_WEEK
-```
-
-`HOURS` denotes working hours rather than calendar time, so it belongs to the physical
-category instead of the period category. This keeps working hours per week distinct from
-a dimensionless ratio; see {ref}`Working hours <gep-10-hours>`.
-
-The Python representation and the YAML representation are two syntaxes for the same
-declaration. Python chains `.PER_` attributes; YAML joins the same components with
-`_PER_`. For example, `TTSIMUnit.CURRENCY.PER_MONTH.PER_BG` corresponds to
-`CURRENCY_PER_MONTH_PER_BG`.
-
-#### Common declarations
-
-| Declaration                           | Resolved dimensionality         | Example                                   |
-| ------------------------------------- | ------------------------------- | ----------------------------------------- |
-| `CURRENCY_PER_MONTH`                  | `CURRENCY / month` (bare)       | personal monthly income                   |
-| `CURRENCY_PER_MONTH_PER_BG`           | `CURRENCY / month / [bg]`       | benefit assigned to a Bedarfsgemeinschaft |
-| `CURRENCY`                            | `CURRENCY` (bare)               | personal wealth                           |
-| `DIMENSIONLESS`                       | `dimensionless`                 | share, rate, indicator, or personal count |
-| `DIMENSIONLESS_PER_FG`                | `1 / [fg]`                      | Familiengemeinschaft indicator            |
-| `DIMENSIONLESS_PER_YEAR`              | `1 / year`                      | annual rate applied to a stock            |
-| `DIMENSIONLESS_PER_BG`                | `1 / [bg]`                      | persons in a Bedarfsgemeinschaft          |
-| `HOURS_PER_WEEK`                      | `[hours] / week` (bare)         | personal weekly working hours             |
-| `CURRENCY_PER_HOURS`                  | `CURRENCY / [hours]`            | hourly wage                               |
-| `CURRENCY_PER_SQUARE_METER_PER_MONTH` | `CURRENCY / meter**2 / month`   | monthly rent ceiling per square meter     |
-| `YEARS`                               | calendar-year duration          | age in years                              |
-| `QUARTERS`                            | calendar-quarter duration       | duration in quarters                      |
-| `CALENDAR_YEAR`                       | point on the calendar-year axis | birth year                                |
-| `CALENDAR_QUARTER`                    | calendar-quarter coordinate     | quarter within the relevant year          |
-
-`CURRENCY` is a placeholder for any currency supported by the policy package. TTSIM
-replaces it with the statutory currency for the selected policy date. This allows the
-same policy function to be used for both DM and Euro periods. Use `CURRENCY` in
-code-side declarations, even if they apply only during a DM or Euro period. Use a
-concrete currency only where the denomination is fixed: parameter declarations in YAML,
-rounding specifications, and unit-annotated input data.
-
-(gep-10-levels)=
-
-### Grouping levels
-
-GETTSIM data has an individual level, identified by `p_id`, and grouping levels
-identified by `*_id` columns. Current examples include households (`hh`),
-Familiengemeinschaften (`fg`), Bedarfsgemeinschaften (`bg`), tax units (`sn`),
-Einsatzgemeinschaften (`eg`), Ehegemeinschaften (`ehe`), and wohngeldrechtliche
-Teilhaushalte (`wthh`). See {ref}`GEP 2 <gep-2>`.
-
-A policy package declares its grouping levels explicitly, by calling
-`register_unit_builder_levels` alongside its unit system. Each declared level gains a
-`PER_<LEVEL>` step on the unit builder and becomes a separate Pint base dimension. There
-is no individual dimension: a quantity that is a property of a person carries no
-grouping level at all and is simply bare.
-
-The domain model contains subset and membership relationships between some groups. The
-unit system does not encode these relationships. It treats `[hh]`, `[bg]`, and other
-levels as non-interconvertible dimensions because group sizes and memberships vary
-across observations.
-
-#### Head counts as level conversions
-
-A head count is dimensionless; at a group level it is a count per group, `1 / [group]`.
-This makes explicit per-capita calculations dimensionally valid: dividing a group total
-by its head count cancels the group level and lands at a bare per-person amount.
-
-```text
-wohnen__bruttokaltmiete_m_hh / anzahl_personen_hh
-  = (CURRENCY / month / [hh]) / (1 / [hh])
-  = CURRENCY / month
-```
-
-Multiplication by a head count converts a bare per-person amount to a group total.
-
-```text
-familie__anzahl_personen_sn * sparerfreibetrag_y
-  = (1 / [sn]) * (CURRENCY / year)
-  = CURRENCY / year / [sn]
-```
-
-Some policy expressions intentionally interpret a group property at another level. Such
-an expression requires `cast_ttsim_unit`, as described in
-{ref}`Explicit exceptions <gep-10-opt-out>`.
-
-For example, in a mixed Bedarfsgemeinschaft, excess income from the SGB XII benefit
-*Grundsicherung im Alter* is calculated at the Einsatzgemeinschaft level but enters the
-Bedarfsgemeinschaft income pool of SGB II Arbeitslosengeld II. The calculation therefore
-casts the amount from `CURRENCY_PER_MONTH_PER_EG` to `CURRENCY_PER_MONTH_PER_BG`.
-
-(gep-10-booleans)=
-
-#### Booleans
-
-A boolean indicates whether a condition holds for a person or group. A person-level
-boolean is bare; a group-level boolean carries that group's level.
-
-| Boolean             | Declaration            | Resolved dimensionality |
-| ------------------- | ---------------------- | ----------------------- |
-| person indicator    | `DIMENSIONLESS`        | `dimensionless` (bare)  |
-| family indicator    | `DIMENSIONLESS_PER_FG` | `1 / [fg]`              |
-| household indicator | `DIMENSIONLESS_PER_HH` | `1 / [hh]`              |
-
-The logical operators `&`, `|`, and `^` preserve the level when both operands have the
-same level. When their levels differ, the result is bare — the individual "level" —
-because the expression is evaluated bit-wise, i.e., per individual row.
-
-```text
-child & requirement_fulfilled_fg
-  = dimensionless & (1 / [fg])
-  = dimensionless
-```
-
-`~` preserves its operand's level. Ordering comparisons require equivalent operand units
-and produce a boolean at the operands' level. Equality comparisons are not unit-checked;
-see {ref}`Limitations <gep-10-limitations>`.
-
-(gep-10-hours)=
-
-### Physical and calendar dimensions
-
-#### Working hours
-
-Working hours use a dedicated `[hours]` dimension rather than Pint's `[time]` dimension.
-Otherwise, hours per week would reduce to a dimensionless ratio and could not be
-distinguished from a share.
-
-`HOURS_PER_WEEK` therefore resolves to `[hours] / [time]`.
-
-#### Calendar points and durations
-
-Calendar coordinates and durations use ordinary integer or floating-point dtypes. Their
-unit determines how TTSIM interprets the value.
-
-A calendar coordinate answers "when within this calendar axis?" For example, `1999` with
-`CALENDAR_YEAR` means the year 1999, `2` with `CALENDAR_QUARTER` means the second
-quarter, `2` with `CALENDAR_MONTH` means February, and `15` with `CALENDAR_DAY` means
-the fifteenth day. The surrounding calculation supplies the wider context:
-`CALENDAR_MONTH` does not encode a year in the same integer.
-
-A duration answers "how long?" The corresponding units are `YEARS`, `QUARTERS`,
-`MONTHS`, and `DAYS`. For example, `18` with `YEARS` is an age or another duration of 18
-years. TTSIM does not automatically convert between these calendar axes. Suffix-driven
-reference-period conversion for flows remains separate and continues to convert between
-`_y`, `_q`, `_m`, `_w`, and `_d`.
-
-The following table defines their supported algebra, where `P` is a point and `D` a
-duration on the same calendar axis.
-
-| Operation                      | Result   | Example                        |
-| ------------------------------ | -------- | ------------------------------ |
-| `P - P`                        | duration | `policy_year - geburtsjahr`    |
-| `P + D`, `P - D`               | point    | `geburtsjahr + statutory_age`  |
-| `P < P`                        | boolean  | `geburtsjahr <= policy_year`   |
-| `P + P`                        | error    | addition of two birth years    |
-| `P * n`, `P / n`               | error    | scaling a calendar point       |
-| point ordered against duration | error    | birth year compared with age   |
-| operation across calendar axes | error    | year point plus month duration |
-
-(gep-10-parameters)=
-
-### Parameter declarations
-
-Units are declared at the time of parameter definition. Given the various parameter
-types, the declaration rules differ slightly.
-
-#### Scalars and dictionaries
-
-A scalar parameter and a dictionary with homogeneous leaves use one unit declaration.
-
-```yaml
-satz:
-  unit: EUR_PER_MONTH
-  type: scalar
-  2023-01-01:
-    value: 250.0
-  2024-01-01:
-    note: Depends on the number of children since 2024.
-satz_nach_kindanzahl:
-  unit: EUR_PER_MONTH
-  type: dict
-  2024-01-01:
-    1: 250.0
-    2: 250.0
-```
-
-A dictionary with heterogeneous leaves uses a mapping from leaf keys to units.
-
-```yaml
-schedule:
-  unit:
-    child_amount_y: EUR_PER_YEAR
-    max_age: YEARS
-  type: dict
-  2024-01-01:
-    child_amount_y: 3000.0
-    max_age: 18
-```
-
-The mapping is the union of leaves that can occur over the parameter's complete date
-range. At a given policy date, validation requires declarations only for leaves present
-in the resolved value.
-
-#### Mapping parameters
-
-A schedule or lookup table is a mapping between quantities. It declares input and output
-axes rather than one scalar unit.
-
-```yaml
-freibetrag_bei_behinderung_gestaffelt_y:
-  input_unit: DIMENSIONLESS
-  output_unit: EUR_PER_YEAR
-  type: piecewise_constant
-  # Intervals omitted.
-```
-
-The parameter schema rejects `unit:` on a mapping type that requires `input_unit:` and
-`output_unit:`. A time suffix in the parameter name describes the output axis and must
-agree with `output_unit`. For example,
-`wohngeld__freibetrag_bei_behinderung_gestaffelt_y` maps a dimensionless disability
-degree to an annual monetary allowance. Its `_y` suffix agrees with
-`output_unit: EUR_PER_YEAR`; the suffix does not constrain its
-`input_unit: DIMENSIONLESS`. A parameter named
-`wohngeld__freibetrag_bei_behinderung_gestaffelt_m` with `output_unit: EUR_PER_YEAR`
-would be rejected because `_m` requires a monthly output.
-
-`require_converter` parameters use one of three forms:
-
-- one `unit:` token for homogeneous content;
-- a per-leaf `unit:` mapping for heterogeneous content; or
-- `input_unit:` and `output_unit:` when the raw YAML value represents a mapping from one
-  quantity to another.
-
-Units of `require_converter` parameters can be declared independently from the units of
-the corresponding `@param_function` as they may differ depending on the conversions in
-the param function.
-
-#### Parameter functions
-
-A `@param_function` converts a raw YAML parameter declared with
-`type: require_converter` into the object used by policy functions. Its unit declaration
-describes that converted result.
-
-**Mapping parameters.**
-
-Parameter functions exposing mapping parameters (of type `PiecewisePolynomialParamValue`
-or `ConsecutiveIntLookupTableParamValue`) declare their input and output unit via
-`unit=InputOutputUnits(...)`:
-
-```python
-@param_function(
-    unit=InputOutputUnits(
-        input_unit=TTSIMUnit.CURRENCY.PER_YEAR,
-        output_unit=TTSIMUnit.CURRENCY.PER_YEAR,
-    ),
-)
-def tarif(...) -> PiecewisePolynomialParamValue: ...
-```
-
-A converter-produced schedule carries the axes declared by its producing
-`@param_function`'s `unit=InputOutputUnits(...)`. Every `look_up` or
-`piecewise_polynomial` call on it screens each domain argument against the declared
-input axis and yields the declared output axis; no cast is needed at the call.
-
-For a multidimensional lookup table, `InputOutputUnits.input_unit` may be a tuple. Each
-tuple element declares the unit of the corresponding positional argument to `look_up`,
-and the number of declared axes must match the number of arguments. A
-`piecewise_polynomial` has exactly one input axis and therefore does not accept a tuple.
-Raw YAML mapping parameters use one `input_unit` token; a tuple is available only on a
-converter-produced schedule or an annotated schedule field.
-
-**Structured parameters.**
-
-Parameter functions exposing structured parameters in the form of generated dataclasses
-declare `unit=UNSET_UNIT` and annotate the fields of the dataclass with units:
+### Canonical value type
+
+Every scalar or array leaf, parameter leaf, schedule coordinate, structured field,
+intermediate expression, generated leaf, and result leaf resolves to the following
+conceptual immutable type.
 
 ```python
 @dataclass(frozen=True)
-class SatzMitAltersgrenzen:
-    satz: Annotated[float, TTSIMUnit.CURRENCY.PER_MONTH]
-    altersgrenzen: Altersgrenzen
-    nach_anzahl_kinder: Annotated[
-        ConsecutiveIntLookupTableParamValue,
-        InputOutputUnits(
-            input_unit=TTSIMUnit.DIMENSIONLESS,
-            output_unit=TTSIMUnit.CURRENCY.PER_MONTH,
-        ),
-    ]
-
-@param_function(unit=UNSET_UNIT)
-def satz_mit_altersgrenzen(...) -> SatzMitAltersgrenzen: ...
+class ValueSpec:
+    unit: PhysicalUnit
+    period: PeriodSpec
+    kind: SemanticKind
+    subject: SubjectSpec
+    extensity: Extensity
+    index: IndexSpec
+    axes: tuple[AxisSpec, ...]
+    calendar: CalendarSpec | None
+    currency: CurrencySpec
+    nullable: bool
 ```
 
-When a policy function accesses an annotated scalar field, the field's unit is used in
-body validation.
+The implementation may use different internal class names, but the fields and their
+semantics are normative. The resolved form MUST contain all fields. `None`, omitted
+fields, or legacy aliases may exist only before resolution, except that `calendar=None`
+is the resolved value for noncalendar kinds and `axes=()` is the resolved value for a
+leaf with no local tensor axes.
 
-If a YAML leaf path matches an annotated field path, validation compares the two
-declarations. This detects, for example, a YAML leaf declared as `YEARS` whose matching
-field is declared as `TTSIMUnit.CURRENCY`. Renamed or derived fields have no matching
-source path and cannot be compared automatically.
+Compound values use a structural type rather than pretending that a dictionary or
+callable has a physical unit.
 
-(gep-10-auto)=
+```python
+@dataclass(frozen=True)
+class StructSpec:
+    fields: Mapping[str, "TypeSpec"]
 
-### Generated nodes and aggregations
 
-#### Reference-period conversions
+@dataclass(frozen=True)
+class MappingSpec:
+    inputs: tuple[ValueSpec, ...]
+    output: "TypeSpec"
 
-A generated reference-period conversion changes only the period component of a unit. For
-example, converting a household amount from monthly to yearly changes
-`CURRENCY_PER_MONTH_PER_HH` to `CURRENCY_PER_YEAR_PER_HH`; the currency base and
-household level remain unchanged. Pint supplies the period ratios used by the numerical
-converter functions.
 
-#### Aggregations
+TypeSpec = ValueSpec | StructSpec | MappingSpec
+```
 
-| Aggregation         | Base                    | Result level                             |
-| ------------------- | ----------------------- | ---------------------------------------- |
-| `SUM`, `MIN`, `MAX` | preserved               | target group (a bare source acquires it) |
-| `SUM` of a boolean  | `dimensionless`         | target group (`1 / [target]`)            |
-| `MEAN`              | preserved               | bare (individual level)                  |
-| `COUNT`             | `dimensionless`         | target group (`1 / [target]`)            |
-| `ANY`, `ALL`        | boolean `DIMENSIONLESS` | target group                             |
+Every compound leaf is therefore checked, while the compound container itself has no
+fake unit, subject, or extensity. A value type is not a runtime wrapper around every JAX
+array. It is static graph metadata and an abstract-interpreter value. Typed input and
+output wrappers expose the same metadata at the boundary.
 
-`COUNT` and a `SUM` over a boolean mint a dimensionless count at the target group level
-(`1 / [target]`), and are bare at an individual target. `SUM`, `MIN`, and `MAX` over a
-non-boolean resolve to the target group level, so a bare source acquires it. A mean is
-bare because it is equivalent to a group sum divided by a head count.
+(gep-10-hours)=
+
+#### Physical unit
+
+`PhysicalUnit` is a Pint unit expression over a policy-package registry. It contains
+only physical measures. The registry includes at least:
+
+- dimensionless one;
+- abstract currency;
+- area, including square meter and hectare;
+- working hours; and
+- additional package-defined physical measures.
+
+Entity domains, persons, groups, booleans, counts, identifiers, calendar points, and
+policy reference periods MUST NOT be Pint base dimensions.
+
+Concrete denominations such as EUR and DM are recorded in `CurrencySpec`; they are not
+separate physical dimensions. Both have physical unit `currency`.
+
+Examples:
+
+| Quantity                                        | `unit`                    | period signature |
+| ----------------------------------------------- | ------------------------- | ---------------- |
+| wealth                                          | `currency`                | `stock`          |
+| monthly income                                  | `currency`                | `per_month`      |
+| hourly wage                                     | `currency / work_hour`    | `stock`          |
+| weekly working hours                            | `work_hour`               | `per_week`       |
+| monthly rent per square meter                   | `currency / square_meter` | `per_month`      |
+| annual rate applied to a stock                  | `one`                     | `per_year`       |
+| Wohngeld coefficient multiplying monthly income | `1 / currency`            | `month`          |
+
+Pint supplies physical equivalence and physical conversion factors. It MUST NOT decide
+policy reference periods or conversion conventions, semantic kind, subject, row index,
+local tensor axes, extensity, calendar algebra, currency provenance, or nullability.
+
+(gep-10-periods)=
+
+#### Policy reference periods
+
+`PeriodSpec` contains a symbolic signature and a conversion convention.
+
+```python
+@dataclass(frozen=True)
+class PeriodSpec:
+    signature: PeriodSignature
+    convention: PeriodConvention
+```
+
+`PeriodSignature` is a multiplicative expression over one policy-reference-time
+dimension, with named units `YEAR`, `QUARTER`, `MONTH`, `WEEK`, and `DAY`. Its canonical
+exponents are signed integers. The named units are convertible under a registered
+convention; they are not independent dimensions. The signature is separate from physical
+time and from calendar duration.
 
 ```text
-(CURRENCY / [hh]) / (1 / [hh])
-  = CURRENCY
+stock       = 1
+per_month   = MONTH^-1
+per_year    = YEAR^-1
+month       = MONTH
+per_month_2 = MONTH^-2
 ```
 
-A hand-written aggregation declares its unit. That declaration must exactly match the
-unit derived from the source, aggregation type, and target level. If an aggregation's
-declared result unit differs intentionally from the derived unit, it must set
-`verify_units=False`.
+The general algebra is required because correct coefficients may carry a period in the
+numerator or higher powers. Public convenience constructors SHOULD cover common stock
+and flow cases.
 
-`@agg_by_p_id_function` assigns each aggregated result to an individual person. Its
-result therefore has no grouping-level denominator. `@group_creation_function` declares
-a unit like any other column function: every column-producing node declares one, without
-exception. A group identifier declares `TTSIMUnit.DIMENSIONLESS`.
+`PeriodConvention` identifies why a conversion factor is valid. Required forms are:
+
+```text
+NONE
+STANDARD_ANNUALIZED[rule_id]
+CALENDAR_ACTUAL[rule_id]
+STATUTORY[rule_id]
+INHERITED[source_node]
+```
+
+Stocks use `NONE`. A standard annualized convention may define an exact context-free
+ratio such as 12 standard months per standard year. An actual-day or statutory proration
+rule may depend on a complete date interval, entitlement days, leap years, or another
+legal convention and therefore uses an explicit graph primitive rather than a
+context-free generated conversion.
+
+A policy package owns an immutable `PeriodSystem` containing named conventions, exact
+factors, valid source and target signatures, and provenance. A generated GEP 1
+conversion is permitted only when the source and target `PeriodSpec` are connected by a
+registered context-free rule. The conversion node records the rule identifier. It MUST
+NOT use a convenient fixed ratio for a quantity declared under an actual-calendar or
+statute-specific convention.
+
+Multiplication and division combine period signatures algebraically and retain enough
+convention provenance to determine whether factors cancel. Convention compatibility is
+checked before period powers cancel; a standard monthly amount and an actual-day
+inverse-month coefficient do not become valid merely because their symbolic exponents
+sum to zero. When compatible period powers cancel to stock, the result convention is
+`NONE` and derivation evidence retains the source conventions. Addition, subtraction,
+branch unification, ordering, minimum, maximum, and clipping require equivalent
+signatures and compatible conventions after an explicitly permitted conversion.
+
+Let `P(source -> target)` be the exact numerical factor registered for one unit of the
+source period convention expressed in the target convention. For period exponent `e`,
+conversion multiplies the magnitude by `P(source -> target)^e`. This rule applies to
+inverse and higher-power coefficients as well as simple flows.
+
+The checker MUST reject a stock returned as a flow, even when both use currency. It MUST
+also reject an untyped coefficient whose missing inverse period happens to be
+numerically harmless in one currency regime.
+
+(gep-10-kinds)=
+
+#### Semantic kinds
+
+The minimum closed set of semantic kinds is:
+
+```text
+NUMBER
+BOOLEAN
+SHARE
+PROBABILITY
+RATE
+COUNT[entity_domain]
+IDENTIFIER[key_domain]
+CATEGORY[category_domain]
+CALENDAR_POINT[axis]
+CALENDAR_DURATION[axis]
+CALENDAR_ORDINAL[axis]
+```
+
+Policy packages MAY register additional semantic kinds with explicit operation rules.
+They MUST NOT treat an unknown kind as `NUMBER` or `DIMENSIONLESS`.
+
+The built-in kinds have these meanings.
+
+- `NUMBER` is a numeric quantity whose physical unit and period carry its dimensional
+  content.
+- `BOOLEAN` is a truth value. It alone may appear in a truth context.
+- `SHARE` is a dimensionless multiplicative fraction. Optional boundary validation may
+  require it to lie in a declared range, commonly `[0, 1]`.
+- `PROBABILITY` is a dimensionless probability. It has stricter aggregation and range
+  semantics than a generic share.
+- `RATE` is a dimensionless or dimensioned multiplicative rate, possibly with a
+  non-stock period signature.
+- `COUNT[E]` records which entity domain is being counted. Count values are intended to
+  be integer-valued and nonnegative; that value constraint is checked at typed
+  boundaries and by generated count operations, rather than being inferred from storage
+  dtype. A count of persons is not a count of households.
+- `IDENTIFIER[K]` is a key in domain `K`. It supports equality, missingness, and
+  relational operations, not arithmetic.
+- `CATEGORY[C]` is a member of a declared finite or open category domain `C`. Categories
+  from different domains are incompatible.
+- Calendar kinds are defined in {ref}`Calendar types <gep-10-calendar>`.
+
+`BOOLEAN`, `IDENTIFIER`, `CATEGORY`, and `COUNT` are never inferred from a dimensionless
+Pint unit. They must be declared or derived by a typed operation. `COUNT[E]` supports
+equality, ordering, and addition or subtraction only with `COUNT[E]` at compatible
+subject and index. A package that requires subtraction to preserve nonnegativity
+attaches a value constraint or uses a registered `count_difference()` primitive. Counts
+do not enter unrestricted numeric arithmetic or stand in for shares, rates, or
+identifiers.
+
+The phrase **numeric kind** in this GEP means `NUMBER`, `SHARE`, `PROBABILITY`, `RATE`,
+or `COUNT[E]` only where the named operation has a rule for that kind. There is no
+implicit coercion from these kinds to `NUMBER`. In particular, physical
+dimensionlessness does not authorize arithmetic between a probability, count, and
+unrestricted number.
+
+(gep-10-subject-index)=
+
+(gep-10-levels)=
+
+#### Subject and index
+
+`subject` identifies the legal or statistical entity a value describes. `SubjectSpec`
+supports `GLOBAL`, one registered entity domain, or a registered composite subject.
+Built-in entity domains include `PERSON` and grouping domains such as `HH`, `BG`, `FG`,
+`SN`, `EG`, `EHE`, and `WTHH`.
+
+`index` identifies where values are represented. It contains a relational row domain and
+a representation contract. The minimum representations are:
+
+```python
+Index.scalar()
+Index.unique(Entity.PERSON)
+Index.unique(Entity.HH)
+Index.broadcast(
+    source=Entity.HH,
+    rows=Entity.PERSON,
+    key=Key.HH_ID,
+)
+Index.gathered(
+    source=Entity.HH,
+    rows=Entity.PERSON,
+    key=Key.HH_ID,
+    cardinality=MANY_TO_ONE,
+)
+```
+
+A subject and an index answer different questions. A household amount repeated on every
+person row still has subject `HH`; its index records person rows and a certified
+household-key broadcast. This distinction lets the checker reject double-counting a
+repeated household value.
+
+Scalar policy parameters use `Index.scalar()` by default. A scalar may be broadcast to
+an array index when its subject and semantic role are compatible with the operation.
+Array-to-array pointwise operations require aligned row domains. Alignment across
+domains occurs only through a typed relation.
+
+The environment MUST know whether an array is unique at its logical source domain or
+repeated. It MUST NOT infer uniqueness merely from a suffix or from observed example
+values.
+
+`axes` contains every non-row tensor dimension in storage order. Each `AxisSpec` has a
+nominal name, a coordinate `ValueSpec` or finite domain, an ordering contract, a
+broadcast rule, and the reducers permitted on that axis. Examples include `choice`,
+`stochastic_node`, `coefficient_order`, and `age_band`. Pointwise operations require
+identical local axes or a registered broadcast. Selecting, stacking, transposing, or
+reducing an axis produces a new explicit axis specification. A raw integer `axis=1` is
+resolved against this metadata; an untyped axis is rejected.
+
+The relational row index and local tensor axes are independent. A person-row array with
+a choice axis has a person `IndexSpec` and one `AxisSpec`; reducing choices does not
+aggregate persons, and aggregating persons does not silently reduce choices.
+
+Pointwise operations combine subjects and row indices by the following fail-closed rules
+after any explicit gather, broadcast, or scalar expansion has been represented in the
+graph.
+
+| Operands                                                                                                    | Result subject and row index                                                          |
+| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| same non-global subject, aligned row index                                                                  | preserve the common subject and aligned index                                         |
+| one `GLOBAL`, `NEUTRAL`, scalar operand                                                                     | preserve the other operand's subject and row index                                    |
+| one registered neutral or intensive modifier explicitly gathered or broadcast into the other operand's rows | preserve the modified operand's subject and row index; retain relation provenance     |
+| different extensive subjects                                                                                | error; use aggregation, allocation, reassignment, or another named semantic primitive |
+| different nonmodifier subjects                                                                              | error even when row lengths and dtypes happen to match                                |
+
+A scalar broadcast changes representation only. It never changes a non-global subject,
+key domain, or extensity. A relation-mediated broadcast can align rows without
+transferring ownership. The primitive's semantic signature decides whether a gathered
+value is a modifier, a comparison threshold, a selection condition, or an amount that
+still requires allocation.
+
+(gep-10-extensity)=
+
+#### Extensity
+
+`Extensity` has at least five values:
+
+```text
+EXTENSIVE
+INTENSIVE
+STATISTIC
+NEUTRAL
+NOT_APPLICABLE
+```
+
+- `EXTENSIVE` values add over disjoint subject entities. Examples include personal
+  income, household rent totals, wealth, and working hours.
+- `INTENSIVE` values are pointwise quantities that do not add over disjoint entities.
+  Examples include shares, averages, wage rates, prices, and densities.
+- `STATISTIC` values are reducer-selected or order-dependent summaries at a target
+  subject, such as minima, maxima, quantiles, and a policy-defined first observation.
+  They are not totals and are not automatically pointwise modifiers. The derivation
+  evidence records the reducer.
+- `NEUTRAL` values are constants, thresholds, coefficients, or modifiers whose use may
+  preserve the extensity of another operand.
+- `NOT_APPLICABLE` is used for booleans, identifiers, categories, and calendar values.
+
+For compatible numeric additions, extensity combines as follows. The table is symmetric
+in its left and right operands.
+
+| Left      | Right                  | Result                                            |
+| --------- | ---------------------- | ------------------------------------------------- |
+| extensive | extensive              | extensive, if subjects match                      |
+| extensive | neutral                | extensive, if subjects are compatible             |
+| intensive | intensive              | intensive, if subjects match                      |
+| intensive | neutral                | intensive, if subjects are compatible             |
+| statistic | statistic              | statistic, if subjects and indices match          |
+| statistic | neutral                | statistic, if subjects are compatible             |
+| neutral   | neutral                | neutral                                           |
+| extensive | intensive or statistic | error                                             |
+| intensive | statistic              | error unless a named primitive defines the result |
+
+A parameter threshold may be `NEUTRAL` while carrying subject `PERSON`; comparison or
+addition to a personal amount is then permitted without making the parameter aggregable.
+Aggregation rules use extensity explicitly and are defined separately.
+
+Generic numeric multiplication and division use the following default extensity rules
+after semantic-kind, subject, index, and local-axis compatibility has been established.
+
+| Operation                                        | Default result                                                            |
+| ------------------------------------------------ | ------------------------------------------------------------------------- |
+| `NEUTRAL * X`, `X * NEUTRAL`, `X / NEUTRAL`      | extensity of `X`                                                          |
+| `EXTENSIVE * INTENSIVE`, `EXTENSIVE / INTENSIVE` | `EXTENSIVE` when the intensive operand is a registered pointwise modifier |
+| `INTENSIVE * INTENSIVE`, `INTENSIVE / INTENSIVE` | `INTENSIVE` only when the semantic-kind rule admits the operation         |
+| `STATISTIC * INTENSIVE`, `STATISTIC / INTENSIVE` | `STATISTIC` only when the intensive operand is a registered modifier      |
+| `STATISTIC * STATISTIC`, `STATISTIC / STATISTIC` | requires an explicit registered rule                                      |
+| `EXTENSIVE * EXTENSIVE`                          | error unless a named primitive defines the resulting meaning              |
+| `EXTENSIVE / EXTENSIVE`                          | requires a declared result kind and rule, commonly a share or rate        |
+| `NEUTRAL / X`                                    | requires an explicit registered rule                                      |
+
+These defaults make wages times hours and prices per area times area extensive while
+rejecting a meaningless product of two totals. A primitive may define another result
+only with an explicit signature and tests.
+
+(gep-10-currency-type)=
+
+#### Currency specification and provenance
+
+`CurrencySpec` is required whenever the physical unit contains a nonzero power of
+currency. It has the conceptual forms:
+
+```text
+NONE
+STATUTORY(policy_date)
+CONCRETE(code, origin, stage)
+DATA(run_argument_or_column_tag)
+INHERITED(source_node, origin_date_rule)
+PRESENTATION(source_node, target_code, conversion_rule)
+```
+
+`NONE` is required when the physical unit has no currency component. `STATUTORY` is used
+by currency-agnostic code-side declarations and resolves to a concrete denomination for
+a policy regime. Parameters, coefficients, rounding magnitudes, and typed input columns
+use a concrete currency or another explicit provenance rule.
+
+`origin` records enough information to answer why a denomination applies. At minimum it
+identifies one of:
+
+- the parameter effective date;
+- the current policy date;
+- the source data tag or `data_currency` assumption;
+- a carried value's originating policy period; or
+- an explicit conversion node and rate definition.
+
+A single ordinary numeric column MUST NOT contain row-wise mixed denominations. A
+package that needs mixed currencies must use a tagged union type and an explicit
+normalization operation; that extension is outside the required first implementation.
+
+Currency compatibility is checked independently of physical-unit equivalence. Two
+monetary values may both have physical unit `currency` and still be incompatible until a
+conversion node aligns their concrete denominations and provenance. Denominations are
+aligned before currency powers cancel: multiplying an EUR amount by a DM
+inverse-currency coefficient does not become valid merely because Pint would produce a
+dimensionless physical unit. After compatible currency factors cancel to exponent zero,
+the result has `CurrencySpec.NONE`, while derivation evidence retains the denominations
+and conversion rules used.
+
+(gep-10-nullability)=
+
+#### Nullability and typed missing values
+
+`nullable` records whether a value may be absent. Missingness is not represented by an
+arbitrary numeric sentinel.
+
+- An optional identifier has type `IDENTIFIER[K]` with `nullable=True`.
+- `MISSING_ID[K]` is a typed missing sentinel for identifier domain `K`.
+- `MISSING` in a branch or join fallback is a polymorphic missing literal that may unify
+  only with a nullable expected type.
+- A nonnullable value cannot receive `MISSING` through `where`, join fallback, lookup,
+  or branch unification.
+- `NaN` is a floating-point value and is not automatically a typed missing value.
+
+The input adapter MAY translate legacy sentinels such as `-1` to `MISSING_ID[K]`, but
+the mapping must be declared at the boundary and must not make equality between
+unrelated numeric and ID values legal inside policy code.
+
+Missing-value semantics are explicit.
+
+- Ordinary arithmetic and compatible comparisons propagate nullability: if any operand
+  may be missing, the result may be missing unless the primitive declares another
+  policy.
+- `is_missing(value)` and `is_not_missing(value)` return a nonnullable boolean at the
+  value's index and local axes. Source syntax `value == MISSING` and `value != MISSING`
+  MAY normalize to these primitives; no other equality with an untyped sentinel is
+  permitted.
+- A nullable boolean cannot control `if`, `where`, masking, `ANY`, or `ALL` until a
+  registered operation resolves missing conditions, for example
+  `fill_missing(condition, False)`.
+- `coalesce(value, fallback)` requires a fallback compatible with the nonnullable form
+  of the value and returns that nonnullable form.
+- Joins, schedules, reductions, and aggregations declare one of `ERROR`, `PROPAGATE`,
+  `SKIP`, or a reducer-specific missing policy. The default is `ERROR`, not
+  backend-dependent behavior.
+- Typed missingness is represented by masks or an equivalent backend-safe form. The
+  checker does not infer it from NaN payloads.
 
 (gep-10-declarations)=
 
-### Declaration rules
+### Declaration syntax and resolution
+
+`ValueSpec` is the canonical leaf representation and `TypeSpec` is the canonical public
+type. Python convenience constructors under `Q` and structured YAML mappings are the
+public declaration syntaxes.
+
+#### Python constructors
+
+The required constructors include at least:
+
+```python
+Q.number(...)
+Q.money(...)
+Q.boolean(...)
+Q.share(...)
+Q.probability(...)
+Q.rate(...)
+Q.count(counted_entity, ...)
+Q.identifier(key_domain, ...)
+Q.category(category_domain, ...)
+Q.calendar_year_point(...)
+Q.date_point(...)
+Q.year_month_point(...)
+Q.calendar_duration(axis, ...)
+Q.month_of_year(...)
+Q.quarter_of_year(...)
+Q.day_of_month(...)
+Q.struct(fields={...})
+Q.mapping(inputs=(...), output=...)
+```
+
+Constructors may provide only documented, type-safe defaults. For example, `Q.money()`
+may supply physical unit `currency`, kind `NUMBER`, and code-side currency `STATUTORY`;
+it may not infer subject or extensity from a name. `Q.identifier(Key.HH_ID)` supplies
+kind and key domain but not an unrelated grouping subject.
+
+#### YAML form
+
+The canonical YAML form is a mapping, not a composite string.
+
+```yaml
+value_type:
+  unit: currency
+  period:
+    signature: per_month
+    convention: gettsim_standard_annualized
+  kind: number
+  subject: person
+  extensity: extensive
+  index: person_unique
+  axes: []
+  calendar: null
+  currency:
+    denomination: EUR
+    provenance: source_column
+  nullable: false
+```
+
+Fields that are structurally fixed by the object MAY be omitted from source YAML but
+MUST appear in the resolved `ValueSpec`. For example, a scalar parameter has
+`index: scalar` and `axes: []`; a generated person-row input has an index supplied by
+its graph node. A compact `period: per_month` alias may expand to a package's explicitly
+named standard convention, but the canonical serialization contains both signature and
+convention. The evidence report records every field that was derived and the named rule
+that derived it.
+
+A compact alias MAY be supported if and only if it expands injectively to one canonical
+mapping. There must be one canonical serialization for equality, hashing, diagnostics,
+and evidence.
 
 #### Declaration matrix
 
-| Object                               | Declaration                                        | Currency base                         | Validation                                    |
-| ------------------------------------ | -------------------------------------------------- | ------------------------------------- | --------------------------------------------- |
-| `@policy_function`                   | required `unit=`                                   | `CURRENCY` for monetary values        | body result, time suffix, and grouping level  |
-| `@policy_input`                      | required `unit=`                                   | `CURRENCY` for monetary values        | time suffix and grouping level                |
-| scalar or dictionary parameter       | `unit:`                                            | concrete currency for monetary values | schema, time suffix, and statutory currency   |
-| mapping parameter                    | `input_unit:` and `output_unit:`                   | concrete currency where applicable    | schema, axes, suffix of the output            |
-| structured `@param_function`         | `unit=UNSET_UNIT`                                  | units on fields                       | field use and matching parameter leaves       |
-| schedule-producing `@param_function` | required `unit=InputOutputUnits(...)`              | agnostic `CURRENCY` only              | schedule call sites screened against axes     |
-| generated time conversion            | assigned automatically                             | inherited agnostic base               | period derived from target suffix             |
-| generated aggregation                | assigned automatically                             | inherited agnostic base               | aggregation rule and target level             |
-| hand-written aggregation             | required `unit=`                                   | `CURRENCY` for monetary values        | exact match with derived unit unless disabled |
-| group-creation function              | required `unit=`                                   | agnostic `CURRENCY` only              | resolved like any other column                |
-| rounding specification               | unit required when attached to a monetary function | concrete currency                     | function unit and statutory currency          |
-| unit-annotated input column          | required on every leaf in that input mode          | concrete currency                     | declared node unit and data currency          |
+| Object                        | Required declaration                        | Additional validation                                                      |
+| ----------------------------- | ------------------------------------------- | -------------------------------------------------------------------------- |
+| `@policy_function`            | `value_type=`                               | body, return, suffix, subject, index, local axes, exceptions               |
+| `@policy_input`               | `value_type=`                               | suffix, subject, index, local axes, boundary compatibility                 |
+| scalar parameter              | `value_type:`                               | dated resolution, concrete currency, leaf shape                            |
+| dictionary parameter          | one type or per-leaf types                  | complete leaf coverage per regime                                          |
+| mapping or schedule parameter | typed input axes and output                 | arity, domain kinds, output suffix                                         |
+| structured parameter function | `Q.struct(fields=...)`                      | field access and source-to-field mapping                                   |
+| generated period conversion   | derived `ValueSpec`                         | only period specification, magnitude, and conversion provenance may change |
+| generated aggregation         | derived `ValueSpec`                         | relation, uniqueness, extensity, result subject                            |
+| join or gather node           | derived `ValueSpec`                         | key domains, cardinality, fallback, row domains                            |
+| hand-written aggregation      | result `value_type=` plus relation metadata | exact agreement with derived rule or assertion                             |
+| group-creation function       | identifier or relation type                 | key domain, uniqueness, membership                                         |
+| rounding specification        | concrete typed magnitudes                   | function type, denomination, effective date                                |
+| typed input column            | complete source `ValueSpec`                 | target compatibility and conversion                                        |
 
-Use `UNSET_UNIT` only on a structured `@param_function` whose return value has no single
-unit. For example, `grundsicherung__regelbedarfsstufen` returns a dataclass containing
-both monthly amounts and age thresholds; the units are declared on its fields. For other
-parameters and aggregations, a missing unit declaration is an error.
+A missing declaration is an error unless a unique normative generated rule supplies it.
+An opaque `UNSET_UNIT` does not satisfy this requirement. Structured values use a
+structured type.
+
+#### Suffix validation
+
+GEP 1 time and grouping suffixes remain useful redundant checks.
+
+- A `_m`, `_y`, `_q`, `_w`, or `_d` suffix must agree with the result's simple flow
+  period when the name denotes a flow.
+- A group suffix must agree with the declared subject where GEP 1 defines that suffix as
+  the subject of the result.
+- An identifier suffix determines a candidate key domain but does not turn a number into
+  an ID.
+- Suffixes do not describe period conventions, extensity, semantic kind, row
+  representation, local tensor axes, join cardinality, calendar semantics, currency
+  provenance, or nullability.
+- A name and declaration disagreement is always an error; neither takes precedence.
+
+(gep-10-rules)=
+
+### Expression type rules
+
+The type checker operates on resolved `ValueSpec` objects. The following rules are
+normative. An implementation may use more detailed internal types but may not accept an
+expression rejected by these rules without an explicit assertion or exemption.
+
+#### Equivalence, compatibility, and conversion
+
+Two value types are **equivalent** when all canonical axes are equal after resolving
+aliases and concrete policy-date metadata. Two value types are **compatible** for a
+named operation when the operation's rule explicitly permits a conversion, scalar
+broadcast, neutral modifier, nullable unification, or relation-mediated alignment.
+
+Physical, period, and currency conversion MUST be explicit in the typed graph, even when
+generated automatically from naming conventions. The abstract interpreter may insert a
+generated conversion node only where the graph builder would insert the same numerical
+conversion and provenance at runtime.
+
+A type comparison MUST NOT reduce to Pint dimensionality alone.
+
+#### Addition and subtraction
+
+Numeric addition and subtraction require:
+
+- compatible semantic kinds;
+- physically equivalent units;
+- equivalent period signatures and compatible conventions after an allowed conversion;
+- compatible currency denomination and provenance;
+- aligned indices and local axes, allowing registered scalar or axis broadcast;
+- compatible subjects; and
+- a valid extensity combination.
+
+The result preserves the common unit, period specification, kind, subject, index, local
+axes, calendar state, and currency; result nullability is the union of operand
+nullability unless a registered missing-value rule resolves it. Extensity is combined by
+the table above.
+
+Identifiers, categories, booleans, and calendar ordinals do not support ordinary numeric
+addition or subtraction. Counts use the same-counted-entity rule above and do not mix
+with unrestricted numbers. Calendar points and durations use their separate affine
+rules.
+
+A subtraction of two compatible extensive amounts remains extensive. A subtraction of
+two calendar points returns a calendar duration. These are different rules and cannot be
+selected from dtype alone.
+
+#### Multiplication and division
+
+Multiplication and division combine physical units and period signatures algebraically
+and carry period-convention provenance through the registered rule. The operation must
+also have a registered semantic, subject, index, local-axis, and extensity rule.
+
+The required built-in rules include:
+
+- `NUMBER × NUMBER` and `NUMBER / NUMBER`, producing `NUMBER` with algebraically
+  combined unit and period;
+- an extensive or intensive numeric quantity multiplied or divided by a `SHARE`,
+  `PROBABILITY`, `RATE`, or neutral coefficient, preserving the quantity's subject and
+  extensity unless the rate's declared semantics specify another result;
+- a neutral coefficient with inverse unit or period multiplying a quantity, with the
+  resulting physical unit, period signature, and convention cancellation checked
+  normally;
+- a typed group-mean, allocation, or count-scaling rule involving `COUNT[E]` and a
+  declared relation; and
+- division of like numeric quantities producing a dimensionless `NUMBER`, `SHARE`, or
+  `RATE` only when the result kind is declared or uniquely implied by the registered
+  primitive.
+
+Plain multiplication by a count does not silently change a person amount into a
+household total. The checker requires `total_from_mean()`, `allocate_equal()`, or
+another registered equivalent carrying the relation and intended result subject.
+Similarly, plain division by a head count does not silently erase or change a group
+subject; `mean_per_member()` and `allocate_equal()` encode the two distinct meanings.
+
+The checker rejects semantic products for which no rule exists, even if the physical
+Pint expression is valid.
+
+#### Ordering comparisons
+
+`<`, `<=`, `>`, and `>=` require comparable numeric or calendar types. Numeric operands
+must have compatible unit, period specification, denomination, subject, extensity role,
+index, and local axes. A scalar neutral threshold may compare with a compatible indexed
+quantity.
+
+The result is `BOOLEAN` at the aligned row index. Its subject is the subject of the
+indexed quantity or the common subject when both are indexed.
+
+Counts may be ordered only against the same `COUNT[E]` kind or a typed count literal.
+Identifiers and categories are not ordered unless their nominal domain explicitly
+registers an ordering. An ID is not ordered merely because its storage dtype is integer.
+
+#### Equality and inequality
+
+Equality is checked; it is not a blanket exemption.
+
+`==` and `!=` are permitted only for:
+
+- equivalent or operation-compatible numeric types;
+- booleans;
+- identifiers in the same key domain;
+- an optional identifier and `MISSING_ID` of the same key domain;
+- categories in the same category domain;
+- compatible calendar values of the same calendar kind and axis; and
+- a nullable value and the typed `MISSING` sentinel, normalized to `is_missing` or
+  `is_not_missing`.
+
+The following are errors:
+
+```python
+monthly_income == annual_income
+hh_id == bg_id
+p_id == -1
+month_of_year == benefit_share
+category_a == category_from_another_domain
+```
+
+Legacy ID sentinel comparisons must be normalized at the input boundary or use a typed
+helper such as `is_missing(id_value)`.
+
+(gep-10-booleans)=
+
+#### Boolean operations and truth contexts
+
+Only nonnullable `BOOLEAN` may be consumed by a truth or logical operation unless the
+primitive has an explicit missing-condition policy.
+
+Python `if`, conditional expressions, `and`, `or`, `not`, and `assert` require a scalar
+boolean: `Index.scalar()` and no non-singleton local axis. A boolean array in a Python
+scalar truth context is rejected even though its semantic kind is correct. Loops are
+outside the initial supported language.
+
+`xnp.where`, `xnp.select`, `xnp.logical_*`, `&`, `|`, `^`, and `~` accept scalar or
+array booleans according to their registered broadcast and alignment rules. Numeric
+bitwise operations are outside the default policy-expression subset. `ANY` and `ALL`
+consume boolean values through typed reduction rules. Direct boolean indexing or masking
+is unsupported unless a registered primitive defines the resulting index, local axes,
+and shape contract.
+
+All non-scalar boolean operands must have aligned row indices and local axes. A group
+boolean gathered to person rows may combine with a person boolean because the relation
+has made the row alignment explicit. The result is a person-row boolean; the gathered
+value's provenance remains available in the expression evidence.
+
+The scalar and vectorized implementations MUST call the same rule. In particular,
+`xnp.where` MUST validate its condition before unifying its result arms.
+
+#### Conditional expressions and branch joins
+
+For `x if condition else y`, `xnp.where(condition, x, y)`, and every other selection
+primitive:
+
+1. `condition` must be boolean and nonnullable, or the selection primitive must declare
+   how a missing condition is resolved;
+1. both result arms are analyzed;
+1. the arms must be equivalent or unify through the typed-zero, typed-missing,
+   scalar-broadcast, or explicitly registered numeric-conversion rules; and
+1. the result is the least type admitted by that rule, including nullability.
+
+The checker must analyze both branches syntactically. It must not depend on a
+placeholder's chosen runtime truth value to discover one branch.
 
 (gep-10-literals)=
 
-### Numerical literals
+#### Numerical literals
 
-Multiplication and division by a dimensionless numerical literal are valid. A
-dimensionless literal cannot be added to, subtracted from, or ordered against a
-dimensioned quantity.
+`True` and `False` are nonnullable `BOOLEAN` literals with global subject, scalar index,
+no local axes, `NOT_APPLICABLE` extensity, and no currency. They may broadcast only
+through a registered boolean or selection primitive.
 
-```python
-betrag_m * 0.5  # Valid: the unit remains CURRENCY_PER_MONTH.
-einkommen_m < 1000.0  # Invalid: the operands have different units.
-```
-
-A dimensioned threshold should normally be a parameter. If it must remain in the
-function body, `cast_ttsim_unit` assigns its intended unit.
+A nonzero numeric literal has type `NUMBER`, physical unit one, stock period, global
+subject, neutral extensity, scalar index, and no currency. It cannot be added to,
+ordered against, or used as a branch replacement for a dimensioned value without an
+explicit typed literal.
 
 ```python
-einkommen_m < cast_ttsim_unit(
-    value=1000.0,
-    unit=TTSIMUnit.CURRENCY.PER_MONTH,
+income_m < quantity_literal(
+    1000.0,
+    value_type=Q.money(
+        period=Period.per_month(),
+        subject=Entity.PERSON,
+        extensity=Extensity.NEUTRAL,
+    ),
+    assertion=AssertionRef("GEP10-LITERAL-001"),
 )
 ```
 
-Zero is the only dimensioned-literal exception. It is accepted as an additive identity,
-return value, comparison bound, or `min`/`max`/`clip` bound and assumes the other
-operand's unit.
+Statutory constants SHOULD be parameters rather than implementation literals.
+
+Literal zero is represented internally as `ZERO_LITERAL`. It may adopt an expected
+numeric type only in these contexts:
+
+- additive identity;
+- a conditional or `where` arm;
+- a `min`, `max`, or `clip` bound;
+- a numeric comparison; or
+- a return with a declared numeric expected type.
+
+Zero cannot adopt `BOOLEAN`, `IDENTIFIER`, `CATEGORY`, or a calendar-point type. `False`
+is a boolean literal, not a numeric zero. A nonzero ID sentinel is never a
+dimensioned-literal exception.
+
+Literal one has a narrower contextual rule. `ONE_LITERAL` may adopt `SHARE` or
+`PROBABILITY` only in a registered complement or unit-interval-bound context, such as
+`1 - probability` or `share <= 1`. It cannot adopt a count, identifier, category,
+dimensioned number, calendar value, or arbitrary rate. Other nonzero share, probability,
+rate, or count constants use typed literals. The evidence and diagnostics record every
+contextual zero or one adoption.
+
+Category, identifier, count, and calendar constants use nominal typed constructors or
+registered enum objects:
 
 ```python
-@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
-def betrag_m(einkommen_m: float, befreit: bool) -> float:
-    return 0.0 if befreit else einkommen_m
+category_literal("single", domain=MARITAL_STATUS)
+identifier_literal(17, domain=Key.HH_ID)
+count_literal(2, counted_entity=Entity.PERSON, subject=Entity.HH)
+month_of_year_literal(2)
 ```
+
+Raw strings and integers do not acquire these kinds from the other operand of an
+equality test. Legacy encodings are decoded at a typed boundary.
+
+#### Minimum, maximum, clipping, and rounding
+
+`min`, `max`, `clip`, `xnp.minimum`, `xnp.maximum`, and their registered variants
+require compatible numeric operands and preserve the unified value type. They do not
+change subject or extensity. A typed zero bound is permitted.
+
+Numerical `round` preserves the value type. Statutory rounding is a graph operation with
+a typed `RoundingSpec` and currency rules defined below.
+
+#### Powers and transcendental functions
+
+Integer powers combine physical and period exponents algebraically. A noninteger power
+requires a resulting physical unit whose exponents remain representable and
+policy-approved, and it is permitted only when the policy reference period remains
+stock. Noninteger powers of currency or a policy reference period are rejected by the
+standard registry; a specialized primitive must normalize those dimensions before
+returning a boundary-convertible value.
+
+`exp`, `log`, and trigonometric functions require dimensionless `NUMBER` inputs with a
+stock period and compatible semantic role. They do not accept shares, probabilities,
+IDs, counts, or calendar values merely because those are physically dimensionless. A
+package may register a specialized transformation with an explicit signature.
+
+(gep-10-calendar)=
+
+### Calendar types
+
+Calendar semantics are separate from physical units and policy reference periods. Every
+calendar value has `unit=one`, `period=stock`, `currency=NONE`, and
+`extensity=NOT_APPLICABLE`. Its calendar semantic kind is paired with a non-null
+`CalendarSpec`:
+
+```python
+@dataclass(frozen=True)
+class CalendarSpec:
+    axis: CalendarAxis
+    system: CalendarSystem
+    arithmetic_rule: CalendarArithmeticRule | None
+    domain: CalendarDomain
+```
+
+`axis` identifies `YEAR`, `YEAR_MONTH`, `DATE`, a duration axis, or an ordinal domain.
+`system` identifies the civil-calendar system, normally the proleptic Gregorian calendar
+for GETTSIM. `arithmetic_rule` names any normalization or end-of-month rule required by
+an admitted operation. `domain` records finite ordinal bounds or the representable point
+domain. The axis encoded in the calendar semantic kind MUST equal `CalendarSpec.axis`.
+Noncalendar kinds require `calendar=None`.
+
+The required calendar types are:
+
+```text
+CALENDAR_POINT[YEAR]
+CALENDAR_POINT[YEAR_MONTH]
+CALENDAR_POINT[DATE]
+CALENDAR_DURATION[YEAR]
+CALENDAR_DURATION[MONTH]
+CALENDAR_DURATION[DAY]
+CALENDAR_ORDINAL[QUARTER_OF_YEAR]
+CALENDAR_ORDINAL[MONTH_OF_YEAR]
+CALENDAR_ORDINAL[DAY_OF_MONTH]
+```
+
+A policy package may add compatible axes. The following distinctions are mandatory.
+
+- `1999` as a year point is affine on the year axis.
+- `(1999, 2)` as a year-month point is affine under explicit month arithmetic.
+- an absolute date is a complete date point.
+- `2` as month of year means February and is a cyclic ordinal, not a point.
+- `15` as day of month is a contextual ordinal, not a point.
+- age in years is a year duration, not a year point and not a policy annual flow period.
+
+#### Supported affine algebra
+
+| Operation                           | Result           | Requirement                               |
+| ----------------------------------- | ---------------- | ----------------------------------------- |
+| year point − year point             | year duration    | same axis and calendar convention         |
+| year point ± year duration          | year point       | same axis                                 |
+| year-month point − year-month point | month duration   | same axis and normalization convention    |
+| year-month point ± month duration   | year-month point | explicit normalized year-month arithmetic |
+| date point − date point             | day duration     | same calendar system                      |
+| date point ± day duration           | date point       | calendar-aware date operation             |
+| date point ± month or year duration | date point       | explicit end-of-month convention          |
+| point ordered against point         | boolean          | same point axis                           |
+| duration ± duration                 | duration         | same duration axis                        |
+| point + point                       | error            | points are affine, not vectors            |
+| point × number                      | error            | no point scaling                          |
+| point ordered against duration      | error            | incompatible calendar kinds               |
+
+Month-of-year, quarter-of-year, and day-of-month ordinals support equality and ordering
+within the same ordinal domain. They do not support point-plus-duration arithmetic or
+subtraction yielding a duration. `December + 2 months` is therefore invalid until
+December is paired with a year to form a year-month point and a wrap convention is
+explicit.
+
+Boundary validation MUST enforce integer or registered-enum representation, `1..4` for
+quarter of year, `1..12` for month of year, and `1..31` for day of month. Fractional
+ordinals are invalid. Actual day validity, including leap-day validity, requires a
+complete date.
+
+`policy_year` is a year point. `policy_month` is a month-of-year ordinal. `policy_day`
+is a day-of-month ordinal. `policy_date` is an absolute date point. The same rules apply
+to evaluation date components.
+
+Flow conversion between monthly and annual amounts is unrelated to calendar-point
+arithmetic. The implementation MUST use distinct classes and rule paths for these
+concepts.
+
+(gep-10-relations)=
+
+### Keys, relations, joins, and alignment
+
+A `RelationSpec` describes a mapping between entity domains. It contains at least:
+
+```python
+@dataclass(frozen=True)
+class RelationSpec:
+    source: EntityDomain
+    target: EntityDomain
+    foreign_key: KeyDomain
+    primary_key: KeyDomain
+    cardinality: Cardinality
+    missing_policy: MissingPolicy
+    uniqueness: UniquenessContract
+```
+
+Key domains are nominal. Equal storage dtype or equal numerical values do not make two
+key domains compatible.
+
+#### Gather and join
+
+A typed gather has the conceptual signature:
+
+```text
+gather(
+    foreign_key: Series[Identifier[K]?, source_rows],
+    primary_key: Series[Identifier[K], target_rows],
+    target: Series[T, target_rows],
+    cardinality: MANY_TO_ONE,
+    on_missing: MissingPolicy[T],
+) -> Series[T, source_rows]
+```
+
+Validation requires:
+
+- equal key domain `K` on foreign and primary keys;
+- nonnullable and unique primary keys;
+- a declared cardinality compatible with the operation;
+- source and target row domains matching the relation;
+- an `on_missing` value that is exactly compatible with `T`, or typed `MISSING` when the
+  resulting gather is nullable;
+- no numeric or category key masquerading as an identifier; and
+- no silent subject reassignment.
+
+The output preserves the target's physical unit, period specification, kind, subject,
+extensity, local axes, calendar, and currency semantics while changing its index to the
+source rows and recording gathered provenance. Its nullability is the union of target
+nullability and the declared missing policy. A later operation may use it as a modifier
+or explicitly reassign or allocate its subject under a policy rule.
+
+One-to-many and many-to-many joins require separate primitives with result-shape
+semantics. They must not be accepted by a many-to-one stand-in.
+
+#### Broadcast and scalar expansion
+
+Scalar expansion is permitted when a scalar's subject and semantic role are compatible
+with the receiving operation. A group-to-person broadcast requires a relation and a
+uniqueness contract. The result index records that values repeat by the declared key.
+
+A repeated value cannot be aggregated over the finer row domain as if every row were an
+independent source value. The checker requires deduplication or aggregation at the
+logical source domain.
+
+#### Subject reassignment and allocation
+
+Some laws deliberately move or allocate an amount between legal entities. This is not a
+unit conversion. It uses a named semantic operation such as:
+
+```python
+reassign_subject(
+    value,
+    to=Entity.BG,
+    relation=EG_TO_BG,
+    assertion=AssertionRef("SGBXII-TO-SGBII-001"),
+)
+```
+
+or an allocation operation that declares weights and conservation rules. These
+operations retain physical unit, period specification, local axes, and currency type but
+change subject and evidence. A generic full-type cast is not the normal interface for
+cross-level policy semantics.
+
+(gep-10-aggregations)=
+
+### Aggregations and reductions
+
+An aggregation is typed by the source value, source index, source uniqueness, relation,
+reducer, target entity and target universe, any weights or ordering, an explicit
+missing-value policy, and an explicit empty-group policy. Physical units alone are
+insufficient. The default missing policy is `ERROR`; `SKIP` changes the effective
+denominator and must be part of the reducer signature and evidence.
+
+Missing source values and empty target groups are different cases. `EmptyGroupPolicy` is
+one of `ERROR`, `MISSING`, or a reducer-specific typed identity. The standard identities
+are typed zero for `SUM` and `COUNT`, `False` for `ANY`, and `True` for `ALL`; a package
+may instead choose `ERROR` or `MISSING`. `MEAN`, `WEIGHTED_MEAN`, `MIN`, `MAX`, `FIRST`,
+and `UNIQUE` have no default identity. A nullable or identity-producing result is
+derived from the declared policy; backend accident is never the source of empty-group
+semantics.
+
+#### Required aggregation rules
+
+| Aggregation                       | Input requirement                                                                             | Result                                                                        |
+| --------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `SUM`                             | extensive numeric value, unique at source entities                                            | same unit and period; extensive; subject and unique index become target       |
+| `SUM` over boolean                | boolean unique at source entities                                                             | `COUNT[source_entity]`; subject and index target                              |
+| `MEAN`                            | numeric value unique at source entities                                                       | same unit and period; intensive statistic; subject and index target           |
+| `WEIGHTED_MEAN`                   | numeric values plus aligned dimensionless weights, normalization rule, and zero-weight policy | same unit and period; intensive statistic; subject and index target           |
+| `MIN`, `MAX` over numeric values  | ordered numeric values                                                                        | same unit, period, and kind; `STATISTIC`; subject and index target            |
+| `MIN`, `MAX` over calendar values | one compatible calendar kind and axis                                                         | same calendar semantics; `NOT_APPLICABLE` extensity; subject and index target |
+| `COUNT`                           | rows or values unique at a declared counted entity                                            | `COUNT[counted_entity]`; subject and index target                             |
+| `ANY`, `ALL`                      | boolean values                                                                                | boolean; subject and index target                                             |
+| `UNIQUE`                          | certified constant or repeated value per target                                               | de-duplicated value at target; otherwise error                                |
+| `FIRST`                           | explicit deterministic ordering and policy meaning                                            | same unit, period, and kind; `STATISTIC` at target plus ordering evidence     |
+
+A mean of person wealth by kinstead is currency-valued, intensive, and has subject
+kinstead. It is not physically `currency / kinstead`, and it is not a person-level
+value.
+
+Weighted means require weights aligned to the source row index and relevant local axes.
+The weight kind is `SHARE` or a registered dimensionless weighting kind; standard
+weights are nonnegative, and a currency amount or count cannot be used as a weight. The
+primitive declares whether it normalizes raw weights, requires them to sum to one, and
+what happens when the total weight is zero. A signed-weight estimator requires a
+separately named primitive. These value constraints are checked where runtime values are
+available and recorded separately from static type evidence.
+
+A sum over a repeated household total on person rows is rejected because the input is
+not unique at the source entities. `UNIQUE` or a group-indexed source must be used
+first.
+
+A hand-written aggregation must provide the same relation metadata and must declare a
+result type that exactly matches the derived rule. A different intended meaning uses a
+named assertion or semantic transformation, not `verify_units=False`.
+
+#### Per-member statistics, allocation, and count scaling
+
+Division by a head count has two common meanings and therefore uses two different
+primitives.
+
+`mean_per_member(total, count, relation)` requires an extensive total whose subject is
+the relation target, a `COUNT[source_entity]` at the same target, and a nonzero-count
+policy. It returns an `INTENSIVE` statistic with the same target subject and target
+index. The value describes the average per source member, but it remains one group-level
+statistic. Broadcasting it to source rows does not change that subject.
+
+`allocate_equal(total, count, relation)` has the same input requirements but returns an
+`EXTENSIVE` amount with source-entity subject and a source-row index. It records an
+equal-allocation and conservation contract: summing the nonmissing allocations through
+the same relation must recover the input total, subject to the declared zero-count and
+numerical-rounding policy. Weighted allocation uses
+`allocate(total, weights, relation, conservation=...)`; weights must be aligned,
+dimensionless shares and their normalization rule must be explicit.
+
+`total_from_mean(mean, count, relation)` may reconstruct an extensive target total from
+a target intensive per-member statistic. `sum_allocations(allocation, relation)`
+aggregates source allocations normally. No generic division or multiplication by a count
+changes subject by itself.
+
+#### In-body array reductions
+
+`xnp.sum`, `xnp.mean`, `xnp.min`, `xnp.max`, and similar reductions MUST inspect
+array-axis metadata. A reduction axis is either:
+
+- a local tensor axis with a declared semantic axis and a registered reduction rule; or
+- a row/entity axis, in which case a `RelationSpec` and target are required.
+
+A `where` mask on a reduction must be a nonnullable boolean aligned with the reduced
+value after registered broadcasting. It is an inclusion mask, not an implicit
+missing-value policy. A reduction that removes an axis removes its `AxisSpec`;
+`keepdims=True` retains a declared singleton form of that axis. The result index and
+remaining local-axis order are derived rather than copied from the input.
+
+A stand-in that discards `axis`, `where`, `keepdims`, weights, initial value, or
+row-domain information is nonconforming. If an axis has no static metadata, the
+reduction is rejected. Contributors may move the operation into a generated typed
+aggregation or register a precise local-tensor signature.
+
+(gep-10-schedules)=
+
+(gep-10-parameters)=
+
+### Parameters, schedules, and structured values
+
+#### Dated scalar and dictionary parameters
+
+A scalar parameter declares one `ValueSpec`. A homogeneous dictionary may share one
+type; a heterogeneous dictionary declares a complete type mapping over the union of leaf
+paths that can exist in any date regime.
+
+Dated declarations use forward fill only where explicitly specified. A dated type
+mapping replaces the prior mapping as a complete mapping unless the schema explicitly
+defines fieldwise inheritance. The value-merging rule and type-inheritance rule are
+separate.
+
+At each validated date regime:
+
+- every resolved leaf has one type;
+- no absent leaf is spuriously required;
+- no present leaf is untyped;
+- concrete monetary types match the applicable statutory denomination and provenance
+  rule; and
+- a value change cannot silently retain an incompatible old type.
+
+#### Mapping and schedule parameters
+
+A mapping parameter uses a typed function signature.
+
+```python
+Q.mapping(
+    inputs=(
+        Q.category(DISABILITY_DEGREE),
+        Q.count(Entity.PERSON, subject=Entity.HH),
+    ),
+    output=Q.money(
+        period=Period.per_year(),
+        subject=Entity.HH,
+        extensity=Extensity.NEUTRAL,
+        currency="EUR",
+    ),
+)
+```
+
+The number and order of input axes must match every lookup call. Each axis carries the
+complete kind, unit, period, calendar, nominal-domain, ordering, and nullability
+semantics needed for lookup or interpolation. Output suffix checks apply to the output
+type only.
+
+Categorical and identifier axes permit exact lookup only. Numeric or calendar axes
+permit interpolation only through a registered method whose signature defines coordinate
+conversion, boundary inclusion, extrapolation, missing values, and result type. A
+schedule wrapper must forward all coordinates and options; discarding a secondary axis,
+interpolation mode, or fallback is a validation failure.
+
+Piecewise-polynomial coefficients declare the mathematically implied unit and period for
+each order. For input type `X` and output type `Y`, an order-`j` coefficient has numeric
+unit and period `Y / X^j`, with compatible semantic and currency provenance. The
+implementation must not label all coefficients dimensionless and rely on
+statutory-currency execution to hide the omission.
+
+#### Parameter functions and structures
+
+A structured parameter function returns `Q.struct(fields=...)`, with a value type for
+every accessible leaf or nested object. `UNSET_UNIT` is not a type. A converter may
+rename, combine, or derive fields, but its body or a registered transformation signature
+must explain the output field types.
+
+A source-to-field comparison is made whenever lineage is known. Renamed or derived
+fields do not become unchecked merely because paths differ; the converter's typed body
+or explicit field mapping supplies the evidence.
+
+Schedule-producing parameter functions declare the complete typed input and output
+signature. Every lookup, interpolation, and polynomial evaluation is validated at the
+call site and in the producer.
+
+(gep-10-generated)=
+
+(gep-10-auto)=
+
+### Generated nodes
+
+#### Reference-period conversions
+
+A generated period conversion changes only:
+
+- the period signature or convention admitted by the named conversion rule;
+- the numerical magnitude by the exact factor and exponent rule in `PeriodSystem`; and
+- period-conversion provenance.
+
+It preserves semantic kind, subject, extensity, index, local axes, calendar state,
+currency denomination, currency provenance, and nullability. It may also update a name
+suffix according to GEP 1.
+
+If a coefficient carries a period in the numerator or a higher power, conversion applies
+algebraically. The system must not assume that every monetary value is a simple flow
+with exponent `-1`. A date-dependent proration is a named calendar/statutory primitive,
+not this generated context-free conversion.
+
+#### Generated grouping nodes
+
+Generated aggregates, joins, group IDs, broadcasts, and per-capita nodes use the
+relational rules above. They do not synthesize Pint group dimensions.
+
+A generated group identifier has kind `IDENTIFIER[group_key_domain]`, not `NUMBER` or
+`DIMENSIONLESS`. A generated membership relation declares source, target, keys,
+cardinality, and missing policy.
+
+#### Generated currency nodes
+
+Currency conversion is represented as an explicit typed boundary or graph node. It
+changes the magnitude, concrete denomination, and provenance record while preserving
+semantic kind, subject, extensity, index, local axes, calendar semantics, and
+nullability. It preserves the physical currency exponent and period specification.
+
+Let `C(source -> target)` denote the exact number of target-currency units equal to one
+source-currency unit. If the physical unit contains currency with signed-integer
+exponent `k`, conversion multiplies the magnitude by `C(source -> target) ** k`. This
+covers inverse-currency coefficients and higher powers; a converter that always
+multiplies by the first-power rate is nonconforming. The standard currency boundary
+rejects noninteger currency exponents.
 
 (gep-10-currency)=
 
-### Currency
+### Currency and statutory computation
 
-#### Registration and statutory currency
+#### Environment-local currency system
 
-A policy package constructs one `UnitSystem` containing its currencies and their
-statutory history. GETTSIM uses Euro as the base currency and defines Deutsche Mark as
-`EUR / 1.95583`.
+Each policy package constructs one immutable `UnitSystem`. Its currency component
+contains:
 
-A system declares its currencies in one ordered mapping, naming each currency exactly
-once. Exactly one of them is the base: it states no `value` and is defined as factor 1
-against the abstract `[currency]` reference. Every other currency states a `value`
-relative to a currency named before it. A currency's `statutory_from` is the date from
-which statutes denominate their numbers in it, until the next currency's date; at least
-one currency must become statutory.
+- a currency family identifier;
+- a closed set of concrete denominations;
+- one exact conversion graph within the family;
+- statutory-effective-date history;
+- conversion-rate provenance; and
+- a policy for carried or retroactive amounts whose denomination is controlled by an
+  origin date other than the current policy date.
 
 ```python
+from fractions import Fraction
+
 UNIT_SYSTEM = UnitSystem(
-    currencies={
-        "EUR": Currency(statutory_from="2002-01-01"),
-        "DM": Currency(value="EUR / 1.95583", statutory_from="1948-06-20"),
-    },
+    currency_family=CurrencyFamily(
+        base="EUR",
+        to_base={
+            "EUR": Fraction(1, 1),
+            "DM": Fraction(100_000, 195_583),  # one DM in EUR
+        },
+        statutory_intervals=(
+            CurrencyInterval("1948-06-20", "2001-12-31", "DM"),
+            CurrencyInterval("2002-01-01", None, "EUR"),
+        ),
+        provenance="legally fixed EUR/DM conversion",
+    ),
+    period_system=GETTSIM_PERIOD_SYSTEM,
+    entities=GETTSIM_ENTITIES,
+    key_domains=GETTSIM_KEYS,
 )
 ```
 
-The policy date determines the computation currency.
+The ordering of mapping entries is not the semantic source of truth. The constructor
+validates a well-founded conversion graph, one base per family, unique names under case
+normalization, and no collision with declaration syntax.
 
-#### Parameter and data currencies
+A `UnitSystem` is passed explicitly or owned by a policy environment. Registering a
+second policy package in the same process cannot mutate the first package's type
+vocabulary or conversion behavior.
 
-Parameters are not converted. Validation instead requires each parameter's concrete
-currency to equal the statutory currency at its policy date. This preserves the values
-specified by the statute, including legally rounded values introduced at a currency
-changeover. The rejected alternative of converting parameters is discussed in
-{ref}`Alternatives <gep-10-alternatives>`.
+#### Statutory denomination
 
-#### Currency changes in parameter histories
+For a policy-date regime, code-side `STATUTORY` monetary types resolve to the concrete
+denomination in which the applicable law writes its parameters and coefficients. A
+monetary parameter or coefficient declares a concrete currency and origin. The
+environment rejects a declaration that is incompatible with its statutory-effective-date
+rule unless the parameter explicitly declares another legally meaningful provenance,
+such as a carried amount from an earlier period.
 
-A dated parameter entry inherits the most recent earlier unit declaration. A new
-declaration replaces the previous declaration from its date onward.
+Parameters and coefficients retain their written numerical values. They are not
+mechanically rewritten into the caller's data currency. This preserves legally rounded
+changeover amounts and currency-dependent formula coefficients.
 
-```yaml
-arbeitnehmerpauschbetrag_y:
-  type: scalar
-  1990-01-01:
-    unit: DM_PER_YEAR
-    value: 2000
-  2002-01-01:
-    unit: EUR_PER_YEAR
-    value: 1044
-  2011-01-01:
-    value: 1000
-```
+The type checker still requires complete units for coefficients. Statutory evaluation
+guarantees a consistent denomination; it does not convert a mathematically
+inverse-currency coefficient into a dimensionless number.
 
-Resolution uses only declarations at or before the policy date. If neither a top-level
-declaration nor an earlier dated declaration exists, the unit is missing.
+#### Carried, retroactive, and mixed-origin amounts
 
-A dated per-leaf mapping replaces the previous mapping completely and must declare every
-leaf present at that date. This rule is independent of `updates_previous`, which
-controls merging of parameter values.
+A value whose denomination is determined by an origin or entitlement period rather than
+the current policy date uses `INHERITED(source_node, origin_date_rule)` or another
+explicit provenance rule. The environment must resolve whether conversion occurs when
+the value is created, carried, combined, or paid.
+
+The current policy date MUST NOT silently relabel a carried DM amount as EUR. Combining
+amounts with different concrete denominations requires an explicit conversion node and
+rate provenance.
+
+Retroactive calculations must state whether statutory rounding occurs in the
+origin-period currency before conversion or in a payment-period currency after
+conversion. The default is no implicit conversion and therefore a validation error until
+the rule is explicit.
+
+#### Boundary conversion order
+
+For ordinary GETTSIM runs, the normative order is:
+
+1. validate or assume the input `ValueSpec`;
+1. convert monetary input to the denomination required at its first policy boundary;
+1. perform policy arithmetic using statutory parameters and fully typed coefficients;
+1. apply each statutory rounding rule in its declared concrete denomination at its
+   declared graph location;
+1. complete all statutory calculations and retain the canonical statutory result; and
+1. derive a requested data-currency presentation view through an explicit output
+   conversion.
+
+The presentation view has `PRESENTATION(...)` provenance and records whether the source
+value had already undergone statutory rounding. It is not relabeled as a legally rounded
+amount in the presentation currency. Typed output can expose both the canonical
+statutory result and the presentation view. Presentation rounding after output
+conversion is nonstatutory and must use a distinct option and evidence record.
+
+#### Numerical representation at the boundary
+
+Currency rates are stored as exact rationals or exact decimal specifications with source
+and legal provenance. Numerical conversion applies the exponent rule above and has the
+following dtype contract.
+
+- Nullable arrays preserve their missing-value mask and convert only present values.
+- Floating-point arrays preserve their floating dtype unless an explicit output-dtype
+  policy says otherwise. The exact factor is rounded once to that dtype under the
+  backend's documented rounding mode. A finite input whose exact converted value is
+  outside the finite range raises `CurrencyConversionOverflow`; finite input must not
+  silently become infinity or NaN.
+- Integer monetary data must either promote to a declared noninteger type or prove exact
+  divisibility for every present value; silent truncation is forbidden.
+- Decimal or exact-rational values use a compatible exact conversion path or fail
+  explicitly.
+- Complex monetary values are rejected.
+- Object arrays are rejected unless one registered converter handles every present
+  element and publishes its result dtype.
+- Existing NaN and infinities are not unit errors. A separate data-validity option may
+  reject or preserve them, and the evidence report must distinguish that policy from
+  type validation.
+- Underflow and backend rounding of finite floating values follow the declared dtype
+  semantics and are covered by numerical conformance tests; the evidence records backend
+  and dtype.
+- Currency conversion must not alter identifiers, categories, booleans, counts, or
+  nonmonetary quantities.
+
+NumPy and JAX front ends must use the same exact registry rate, exponent, promotion
+policy, and operation order. Bitwise equality across backends is not promised where
+their documented floating-point semantics differ, but each result must satisfy the
+package's stated dtype-level numerical tolerance and all no-truncation,
+no-silent-overflow, and rounding-order requirements.
 
 (gep-10-rounding)=
 
-#### Rounding specifications
+### Rounding specifications
 
-A monetary rounding specification declares the concrete currency and complete unit of
-its numerical magnitudes.
+A statutory `RoundingSpec` declares typed magnitudes, concrete denomination,
+effective-date range, and legal reference.
 
 ```python
 @policy_function(
-    end_date="2001-12-31",
-    leaf_name="zu_versteuerndes_einkommen_y_sn",
+    value_type=Q.money(
+        period=Period.per_year(),
+        subject=Entity.SN,
+        extensity=Extensity.EXTENSIVE,
+    ),
     rounding_spec=RoundingSpec(
         base=54,
         direction="down",
         to_add_after_rounding=27,
+        value_type=Q.money(
+            period=Period.per_year(),
+            subject=Entity.SN,
+            extensity=Extensity.NEUTRAL,
+            currency="DM",
+        ),
         reference="§ 32a Abs. 2 EStG",
-        unit=TTSIMUnit.DM.PER_YEAR.PER_SN,
     ),
-    unit=TTSIMUnit.CURRENCY.PER_YEAR.PER_SN,
+    end_date="2001-12-31",
 )
-def zu_versteuerndes_einkommen_y_sn(): ...
+def zu_versteuerndes_einkommen_y_sn() -> float: ...
 ```
 
-The rounding unit must equal the function unit after replacing `CURRENCY` with the
-concrete statutory currency. A function that remains active across a statutory-currency
-change must be split and receive separate rounding specifications.
+The rounding magnitude's physical unit, period specification, subject compatibility, and
+concrete denomination must match the value being rounded after resolving `STATUTORY`. A
+function active across a statutory-currency or rounding-rule change must have dated
+rounding regimes or split definitions.
+
+The maximal date partition includes every rounding start, end, and rule change. A
+rounding rule cannot be inherited across a denomination change by accident.
+
+(gep-10-validation)=
 
 (gep-10-checks)=
 
-### Validation and limitations
+### Validation architecture
 
-#### Validation stages
+Validation has seven distinct stages. Implementations may combine passes internally, but
+evidence must preserve the distinction.
 
-| Stage                                    | When                                        | Input                                  | Validates                                                            |
-| ---------------------------------------- | ------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------- |
-| declaration validation                   | decoration or parameter loading             | declarations                           | required fields, grammar, suffixes, allowed currency bases           |
-| environment and function-body validation | policy-environment assembly                 | unit-carrying test values              | function bodies, returns, branches, aggregations, statutory currency |
-| input-boundary validation                | processing unit-annotated input in `main()` | user tags and node declarations        | physical dimension, period, level, and source currency               |
-| numerical boundary conversion            | before and after TT computation             | arrays, scalars, and conversion factor | input to statutory currency; computed results to data currency       |
+| Stage                            | Validates                                                                  |
+| -------------------------------- | -------------------------------------------------------------------------- |
+| declaration parsing              | syntax, required fields, closed enums, registry membership                 |
+| canonical resolution             | complete `ValueSpec`, defaults, aliases, currency and date resolution      |
+| graph validation                 | edge compatibility, generated conversions, relations, joins, aggregations  |
+| body abstract interpretation     | supported expressions, branches, calls, returns, assertions                |
+| regime validation                | maximal policy-date partition and all active declarations in each interval |
+| input/output boundary validation | source tags, dtypes, ranges when requested, conversion                     |
+| evidence and release gate        | statuses, coverage, exceptions, expiry, conformance suite                  |
 
-The implementation uses Pint while declarations and policy environments are validated,
-while explicitly annotated input is processed, and while numerical conversion factors
-are derived. Pint quantities do not enter the compiled tax and transfer function or a
-JAX trace. Currency conversion of input arrays, scalar input values, and result arrays
-is ordinary numerical multiplication at the interface boundary.
+Passing declaration parsing does not imply that a body was checked. Passing body
+validation at one date does not imply that all parameter or currency regimes were
+checked.
 
-#### Function-body validation
+(gep-10-body-checker)=
 
-To validate a function body, TTSIM runs it with placeholder values that carry the
-declared units instead of actual data. It then checks that the operations and returned
-value are consistent with those units.
+### Function-body abstract interpretation
 
-```python
-@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_HH)
-def bruttokaltmiete_m_hh(...) -> float: ...
+#### Supported-language contract
 
-@policy_function(unit=TTSIMUnit.DIMENSIONLESS.PER_HH)
-def anzahl_personen_hh(...) -> int: ...
+TTSIM validates policy bodies by parsing the supported Python subset into a typed
+intermediate representation and interpreting that representation over abstract
+`ValueSpec` values. It does not claim that arbitrary placeholder execution proves a
+function correct.
 
-@policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
-def bruttokaltmiete_m(
-    bruttokaltmiete_m_hh: float,
-    anzahl_personen_hh: int,
-) -> float:
-    return bruttokaltmiete_m_hh / anzahl_personen_hh
+The supported subset includes, at minimum:
+
+- local assignments and returns;
+- arithmetic and comparison operators with registered rules;
+- boolean operators, scalar truth contexts, and `assert` statements;
+- conditional statements and conditional expressions;
+- attribute and field access on typed structures;
+- typed indexing, slicing, stacking, and selection with registered index and local-axis
+  rules;
+- calls to typed policy functions, parameter functions, schedules, and registered
+  primitives;
+- scalar and vectorized `xnp` operations with registered signatures; and
+- explicit assertion and semantic-conversion primitives.
+
+Loops, comprehensions, dynamic dispatch, reflection, mutation, exception-driven control
+flow, or calls whose target cannot be resolved are unsupported until a sound rule is
+registered.
+
+Unsupported syntax is a validation failure with status `UNSUPPORTED_BODY`. It must not
+be executed with a permissive stand-in that guesses a result type.
+
+#### Syntax-directed branch analysis
+
+The checker analyzes every syntactic branch and joins branch result types. It does not
+choose a truth value for an abstract operand to discover one path at a time.
+Consequently, a function with `n` independent conditions does not require enumerating
+`2^n` placeholder executions merely to check branch return types.
+
+Where value-dependent refinement is needed, the checker may refine nullability, category
+variants, or other finite type facts. Such refinement must be conservative and
+documented. Failure to prove a refinement rejects the dependent operation rather than
+assuming it.
+
+A resource limit may protect the checker from pathological source. Crossing it produces
+a visible `CHECKER_RESOURCE_LIMIT` failure. It does not turn the body into a verified
+declaration.
+
+#### One primitive registry
+
+All operations are registered in one immutable primitive-signature registry owned by the
+`UnitSystem`. Scalar, vectorized, and generated front ends lower to the same primitive.
+
+Each registry entry declares every public alias, complete argument roles, result rule,
+supported index and local-axis broadcasts, value constraints, backend availability, and
+conformance tests. The implementation generates a public operation inventory from this
+registry. A scalar or vectorized alias without an entry, or an entry without required
+mutation and parity tests, fails the release gate.
+
+Examples:
+
+```text
+Python ternary     ─┐
+xnp.where          ├─> SELECT(condition, true_value, false_value)
+xnp.select         ┘
+
+Python sum         ─┐
+xnp.sum            ├─> REDUCE_SUM(value, axis, relation, options)
+generated SUM      ┘
 ```
 
-The arguments resolve to `CURRENCY / month / [hh]` and `1 / [hh]`. Their division
-resolves to `CURRENCY / month` (bare), which matches the declaration.
+A vectorized wrapper must forward every type-relevant argument. Ignoring `condition`,
+`axis`, `where`, `keepdims`, fallback, key, cardinality, local axes, weights, or missing
+policy is nonconforming. The registry test harness mutates each type-relevant argument
+independently and requires the scalar, vectorized, and generated aliases to return the
+same resolved type or the same type-axis failure whenever their numerical semantics are
+equivalent.
 
-Conditional branches are explored by re-evaluating the body with different branch
-decisions. Each explored return path is checked separately. Vectorized `xnp` operations
-implemented by the validator use the same unit rules as their scalar equivalents.
+#### Return validation
 
-Body validation rejects:
+Each return expression is checked against the function's declared `TypeSpec`. Leaf
+checks cover all canonical axes, not only Pint dimensionality, and structural checks
+cover field names, container shape, and mapping signatures. A return is rejected when,
+for example:
 
-- addition, subtraction, or ordering of non-equivalent quantities;
-- a non-zero bare literal used as a dimensioned value;
-- a return unit that differs from the declaration in physical dimension, period, or
-  grouping level;
-- logical operators applied to non-boolean values;
-- an untyped numerical value accessed from a structured parameter;
-- inconsistent schedule input and output axes; and
-- unsupported operations unless the function explicitly disables body validation.
+- wealth is declared as monthly income;
+- a household total is declared as a person amount;
+- a mean is declared as extensive;
+- an `Id[HH]` is declared as an unrestricted number;
+- a nullable branch is declared nonnullable;
+- a month-of-year ordinal is declared as a month duration; or
+- a concrete currency or provenance is incompatible with the regime.
 
-(gep-10-limitations)=
+A function with no verified body may still expose its declared result to consumers only
+through a structured exemption. The consumer contract does not retroactively verify the
+producer.
 
-#### Trade-offs and limitations
+(gep-10-date-partition)=
 
-**Equality is unchecked.** Equality operators do not compare units, so a monthly income
-can be compared with an annual income without detection. This permits comparisons such
-as `p_id_empfänger == -1`. Use ordering or an explicit policy condition where
-dimensional equivalence matters.
+### Maximal policy-date partition
 
-**Branch exploration is bounded.** Environment assembly fails when a function exceeds
-1,024 paths or 64 decisions; simplify its body.
+Validation must cover every interval on which the resolved policy environment is
+structurally and typically constant. Testing only function start and end dates is
+insufficient.
 
-**Some operations are unsupported.** For example, a function body using `join` is
-rejected if the validator has no implementation for that operation. Add validator
-support, use a local `cast_ttsim_unit`, or use `verify_units=False`.
+Let `B` be the set of effective boundaries contributed by:
 
-**A cast is an assertion.** An incorrect cast from a Bedarfsgemeinschaft amount to a
-household amount can hide an error. Keep casts local and review them as policy
-assumptions.
+- policy-function and policy-input start dates;
+- the calendar day after each inclusive function or input end date;
+- every dated parameter value entry;
+- every dated parameter type, physical unit, period signature or convention, kind,
+  subject, extensity, index, local-axis, currency, nullability, leaf-set, or
+  mapping-axis entry;
+- parameter-function and structured-field schema changes;
+- schedule domain, arity, interpolation, and coefficient-schema changes;
+- statutory-currency start dates and conversion-rate regime changes;
+- period-conversion convention, factor, and date-aware rule regime changes;
+- rounding-rule starts and the day after inclusive ends;
+- relation, key-domain, cardinality, grouping, aggregation, and generated-node validity
+  changes;
+- naming or schema migrations that affect active declarations; and
+- the configured beginning and end of the policy package's supported date domain.
+
+The implementation sorts and deduplicates `B`. Each adjacent pair defines a half-open
+interval `[B_i, B_{i+1})`; the final boundary defines an open-ended interval if the
+policy domain permits one. Validation resolves the environment at the left endpoint of
+every interval. Inclusive end dates are represented by adding their successor date to
+`B`.
+
+Every boundary carries provenance identifying which declaration introduced it. The
+evidence report publishes the complete partition and the source boundaries.
+
+A parameter-only change therefore creates a new validation regime even when every
+function remains active. A currency-only or rounding-only change does the same.
+
+Runtime parameters may change magnitudes but MUST NOT change `ValueSpec`, leaf shape,
+index, local axes, key domain, or schedule arity within a compiled regime. Such
+structural dependence requires separate static regimes. Dynamic container shape or
+leaf-set variation is unsupported until a future explicit variant `TypeSpec` is
+standardized; an assertion cannot smuggle it through an ordinary `StructSpec` or
+`MappingSpec`.
+
+(gep-10-evidence)=
+
+### Verification evidence and coverage
+
+Every active producer in every date interval receives one primary evidence status and
+zero or more qualifiers. Compound producers additionally report a resolved `ValueSpec`
+and derivation for each active leaf.
+
+Required primary statuses are:
+
+```text
+BODY_VERIFIED
+DERIVED_BY_GENERATED_RULE
+INTERFACE_VERIFIED_ONLY
+DECLARED_ONLY_EXEMPTION
+UNSUPPORTED_BODY
+UNRESOLVED_TYPE
+```
+
+Required qualifiers include:
+
+```text
+TYPE_ASSERTION_USED
+SEMANTIC_REASSIGNMENT_USED
+INPUT_TYPE_ASSUMED
+RUNTIME_RANGE_CHECKED
+CURRENCY_CONVERTED
+LEGACY_ADAPTER_USED
+```
+
+Their meanings are:
+
+- `BODY_VERIFIED`: the supported body and return were checked by the abstract
+  interpreter.
+- `DERIVED_BY_GENERATED_RULE`: the node has no ordinary body; a named relation,
+  aggregation, conversion, or graph-construction rule derived and checked its type.
+- `INTERFACE_VERIFIED_ONLY`: the declaration and boundary contract were checked, but the
+  producer body is external or otherwise outside the checker.
+- `DECLARED_ONLY_EXEMPTION`: a structured exemption supplies the consumer result
+  contract; the body was not verified.
+- `UNSUPPORTED_BODY`: the source uses unsupported syntax or an unregistered primitive.
+- `UNRESOLVED_TYPE`: one or more canonical axes could not be resolved.
+
+A package cannot pass the default conformance gate with `UNSUPPORTED_BODY` or
+`UNRESOLVED_TYPE`. An organization may permit listed `DECLARED_ONLY_EXEMPTION` nodes
+under an explicit policy, but it must not report them as verified.
+
+The machine-readable report contains at least:
+
+```json
+{
+  "interval": ["2024-01-01", "2024-12-31"],
+  "node": "housing.amount_m_hh",
+  "resolved_value_type": {},
+  "primary_status": "BODY_VERIFIED",
+  "qualifiers": [],
+  "checker_version": "...",
+  "source_digest": "...",
+  "unit_system_digest": "...",
+  "primitive_registry_digest": "...",
+  "date_partition_digest": "...",
+  "derivation": [],
+  "assertions": [],
+  "exemptions": []
+}
+```
+
+The release summary reports separately:
+
+- active nodes and date intervals;
+- declaration-resolution coverage;
+- body-verified coverage;
+- generated-rule coverage;
+- interface-only coverage and the enumerated trusted external primitives;
+- assertion count and affected nodes;
+- semantic-reassignment count;
+- whole-body exemption count;
+- assumed-input count;
+- unsupported and unresolved counts; and
+- intervals validated versus intervals in the maximal partition.
+
+“100% annotated” is not a synonym for “100% body verified.” The report must not combine
+them into one percentage.
+
+(gep-10-exceptions)=
 
 (gep-10-opt-out)=
 
-#### Explicit exceptions
+### Assertions, semantic conversions, and exemptions
 
-`cast_ttsim_unit(value, unit=unit)` changes the inferred unit of one expression during
-body validation. At numerical execution it returns `value` unchanged. It is appropriate
-for:
+#### Typed literals
 
-- policy-defined arithmetic whose grouping interpretation differs from the general
-  aggregation rules, such as transferring SGB XII excess income from an
-  Einsatzgemeinschaft into the SGB II Bedarfsgemeinschaft income pool;
-- a calendar-axis conversion, such as casting a month coordinate to a `MONTHS` offset
-  before adding it to a value converted from `CALENDAR_YEAR` to `CALENDAR_MONTH`; or
-- a dimensioned implementation constant that is not a statutory parameter, such as a
-  `0.00001 YEARS` numerical tolerance when comparing age with a retirement-age
-  threshold.
+`quantity_literal` assigns a type to an implementation constant. It requires an
+`AssertionRef` that points to structured metadata. This operation is narrower than a
+generic type cast because it starts from a literal and cannot relabel an existing
+computed quantity.
 
-Because a cast replaces the complete inferred unit, including its grouping level, it
-should apply to the smallest expression that requires it.
+#### Semantic transformations
 
-`verify_units=False` disables body validation for one decorated function or aggregation.
-Its declared output unit remains the contract used by consumers. It is appropriate only
-when the body uses an unsupported operation, exceeds branch-exploration limits, or
-cannot express its policy interpretation using the standard aggregation rules.
+Alignment, subject reassignment, allocation, per-capita conversion, and calendar
+construction use named primitives with explicit preconditions and result rules. Their
+evidence names the relation or legal interpretation. They are not generic physical-unit
+conversions.
+
+#### Last-resort type assertion
+
+`assert_value_type(value, expected=..., assertion=...)` may supply unresolved axes or
+refine a broader nominal domain only when the standard type language cannot express a
+valid policy interpretation. It returns the runtime value unchanged. It MUST NOT
+contradict a known physical unit, period signature or convention, semantic kind,
+subject, index, local axis, concrete currency, or nullability. A known conflict requires
+a numerical conversion, named semantic transformation, boundary decoder, formula repair,
+or whole-producer exemption; it cannot be erased by assertion.
+
+Every assertion record contains:
+
+```python
+TypeAssertion(
+    id="GEP10-A012",
+    reason="Why the inferred and asserted types differ",
+    reference="Statute, design document, or derivation",
+    owner="team-or-person",
+    issue="tracking issue or permanent-decision record",
+    expires="2027-06-30",  # or permanent=True with justification
+)
+```
+
+The assertion applies to the smallest expression that requires it. It cannot be used to
+repair a known false declaration, such as relabeling wealth as monthly income, or to
+turn a family total into a person allocation. The checker records the unresolved or
+broad inferred type, the asserted refinement, and every affected consumer.
+
+#### Whole-body exemption
+
+A body exemption has the form:
+
+```python
+ValidationExemption(
+    id="GEP10-E004",
+    reason="Unsupported external primitive",
+    unsupported_construct="library.function",
+    owner="team-or-person",
+    issue="https://...",
+    expires="2027-03-31",
+)
+```
+
+An exempt function still declares a complete output `ValueSpec`, which consumers use as
+an interface contract. Its evidence status is `DECLARED_ONLY_EXEMPTION`. Missing
+metadata, an expired record, or an exemption not present in the policy package's
+reviewed manifest is a release error.
+
+The default CI policy rejects an increase in assertions or exemptions unless the change
+updates an approved manifest and its review record. A permanent exemption must name a
+stable external contract and explain why a typed primitive signature is not feasible.
+
+`verify_units=False` and unstructured casts are nonconforming.
+
+(gep-10-boundary)=
+
+### Input-boundary validation
+
+For fully typed input, every leaf has a source `ValueSpec`. Validation checks:
+
+- semantic kind and nominal domains;
+- physical-unit and period-specification compatibility;
+- subject and index compatibility;
+- representation, uniqueness, key, and local-axis requirements;
+- extensity;
+- calendar kind and axis;
+- currency denomination and provenance;
+- nullability; and
+- optional dtype, range, uniqueness, and finiteness contracts.
+
+Only registered physical, period, and currency conversions change magnitudes.
+Semantic-kind, subject, key-domain, category-domain, and calendar-kind mismatches are
+errors.
+
+Semantic kinds may imply value constraints that are not purely static. Fully typed
+boundaries MUST check boolean representation, identifier and primary-key validity,
+category-domain membership, integer-valued counts, declared count nonnegativity,
+probability range, and calendar-ordinal ranges. Other share or rate ranges are checked
+when their declaration supplies a constraint. Computed values receive
+`RUNTIME_RANGE_CHECKED` only when an enabled runtime validator actually checks them; a
+static `BODY_VERIFIED` status alone does not prove ranges.
+
+For untyped input, the policy node supplies the expected `ValueSpec`; `data_currency`
+supplies a monetary-denomination assumption. The evidence uses `INPUT_TYPE_ASSUMED`. The
+system may still perform GEP 9 dtype checks, key uniqueness checks, and configured
+value-range checks.
+
+Typed output contains the fully resolved result type. A requested raw parameter retains
+its own statutory type and is not relabeled as a computed output in data currency.
+
+(gep-10-failures)=
+
+### Failure policy and diagnostic requirements
+
+Validation is fail-closed. An unknown operation, missing type axis, incompatible
+relation, or uncovered date interval is an error unless a valid structured exemption
+applies.
+
+Diagnostics must identify:
+
+- the node and date interval;
+- source location and expression;
+- the complete left and right or expected and actual value types;
+- the specific axis that failed;
+- any relation, key, or aggregation involved;
+- the derivation path for generated fields; and
+- the assertion or exemption that would be required, without suggesting a generic cast
+  as the default repair.
+
+For branch failures, diagnostics identify the syntactic branch and both arm types. For
+scalar and vectorized variants, equivalent source expressions should produce equivalent
+diagnostics.
+
+A failure in one interval does not suppress analysis of other intervals when the checker
+can continue safely; the final report may aggregate failures. A package cannot claim
+conformance until all blocking failures are resolved.
+
+(gep-10-conformance)=
+
+## Conformance and acceptance requirements
+
+An implementation conforms to this GEP only if all mandatory requirements below are met.
+Green project tests without these cases are not sufficient evidence.
+
+### Core type-model requirements
+
+1. The canonical leaf type separates physical unit, period signature and convention,
+   semantic kind, subject, relational index, local tensor axes, extensity, calendar
+   semantics, currency provenance, and nullability; compound values use structural
+   `TypeSpec` variants.
+1. Pint is used only for physical-unit algebra and conversion. Entity domains and
+   semantic kinds are not Pint dimensions.
+1. Dimensionless values are not accepted without a semantic kind.
+1. Identifiers and categories use nominal domains.
+1. Currency denomination and provenance are checked separately from physical currency
+   dimension.
+1. The complete resolved type is serializable canonically and hashable for graph
+   validation and evidence.
+1. Type vocabularies, period systems, and primitive registries are immutable and
+   environment-local; construction, import order, threads, and concurrent validation do
+   not change another environment's accepted vocabulary or rules.
+
+### Expression-language requirements
+
+The conformance suite must include at least the following mutation tests.
+
+| Case                                                                                                                                        | Required result                                                                      |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| use currency, wealth, count, ID, or category in Python `if`, `and`, `or`, `not`, `bool()`, or `assert`                                      | reject as nonboolean truth context                                                   |
+| use a boolean array directly in Python `if`, `and`, `or`, `not`, `bool()`, or `assert`                                                      | reject as nonscalar truth context                                                    |
+| use any `while` loop in the initial language                                                                                                | reject as `UNSUPPORTED_BODY`; never validate it through placeholder truth evaluation |
+| use `for`, a comprehension, `match`, a closure with unresolved captures, reflection, mutation, or exception-driven control flow             | reject deterministically as `UNSUPPORTED_BODY` until a sound rule is registered      |
+| call an unregistered `numpy`, `xnp`, helper, or dynamically resolved function                                                               | reject; never execute a metadata-dropping fallback                                   |
+| branch on array shape, row count, or another runtime value through unsupported Python control flow                                          | reject rather than certify one observed path                                         |
+| use the same nonboolean values as `xnp.where` condition                                                                                     | reject with the same kind rule                                                       |
+| use aligned boolean array as `xnp.where` condition with matching arms                                                                       | accept                                                                               |
+| use nullable boolean as condition without a missing-condition policy                                                                        | reject                                                                               |
+| fill nullable boolean explicitly and use it as condition                                                                                    | accept as nonnullable boolean                                                        |
+| replace a scalar conditional with its equivalent vectorized conditional                                                                     | same resolved type or same failure                                                   |
+| compare monthly and annual income with equality                                                                                             | reject unless an explicit generated period conversion aligns them                    |
+| compare `Id[HH]` with `Id[BG]`                                                                                                              | reject                                                                               |
+| compare optional `Id[HH]` with `MISSING_ID[HH]`                                                                                             | accept as nonnullable `is_missing` test                                              |
+| combine nullable arithmetic operands                                                                                                        | result nullability is the union of operand nullability                               |
+| compare `Id[HH]` with literal `-1`                                                                                                          | reject inside policy code                                                            |
+| add `COUNT[PERSON]` to `COUNT[PERSON]` at the same subject and index                                                                        | accept as `COUNT[PERSON]`                                                            |
+| add `COUNT[PERSON]` to `COUNT[HH]` or to an unrestricted number                                                                             | reject                                                                               |
+| add wealth stock to monthly income                                                                                                          | reject                                                                               |
+| return wealth from a function declared as monthly income                                                                                    | reject                                                                               |
+| multiply a monthly income by a correctly typed month-per-currency coefficient under the same period and currency conventions                | accept with dimensionless result                                                     |
+| use an inverse-currency coefficient in a different denomination without conversion                                                          | reject before currency factors cancel                                                |
+| declare the coefficient dimensionless                                                                                                       | reject the formula                                                                   |
+| apply a fixed annualized conversion to an actual-day statutory amount                                                                       | reject; require the named date-aware rule                                            |
+| use nonzero bare threshold against dimensioned amount                                                                                       | reject                                                                               |
+| use typed zero against dimensioned amount                                                                                                   | accept and record its contextual type                                                |
+| use `1 - probability` or `share <= 1`                                                                                                       | accept through the contextual one rule                                               |
+| use one as count, ID, calendar point, or dimensioned amount                                                                                 | reject                                                                               |
+| use zero as ID or calendar point                                                                                                            | reject                                                                               |
+| apply `log` to a share, count, or identifier                                                                                                | reject unless a specialized primitive is registered                                  |
+| call a schedule with the wrong arity, axis kind, calendar axis, category domain, or fallback type                                           | reject at the call site                                                              |
+| mutate a schedule wrapper so that it drops a coordinate, interpolation rule, extrapolation rule, or fallback                                | fail registry parity or argument-mutation tests                                      |
+| evaluate a polynomial whose order-`j` coefficient lacks type `Y / X^j`                                                                      | reject the coefficient or evaluation                                                 |
+| access an absent or untyped structured field                                                                                                | reject; do not return an opaque placeholder type                                     |
+| swap two differently typed structured fields while keeping container shape                                                                  | reject from field lineage or return validation                                       |
+| mutate a generated period conversion so that it changes subject, index, local axes, extensity, calendar semantics, currency, or nullability | reject the derived node                                                              |
+| use `assert_value_type` to relabel wealth stock as monthly income                                                                           | reject the assertion as contradicting a known type                                   |
+
+Every scalar, vectorized, and generated alias in the public operation inventory must be
+covered by registry-generated parity and independent-argument mutation tests. A boolean
+condition, reduction axis, fallback, key, relation, or option omitted by a wrapper must
+cause a test failure.
+
+### Reference-period requirements
+
+The conformance suite must show that:
+
+- standard monthly and annual flows convert through a named exact annualized rule and
+  round-trip under the exact arithmetic reference implementation;
+- inverse and higher-power period coefficients use the exponent-aware factor;
+- source and target conventions appear in the resolved type and conversion evidence;
+- an actual-day, leap-year, 30/360, or statute-specific amount is not converted by the
+  standard fixed-ratio rule;
+- a date-aware proration primitive receives the complete required calendar context and
+  publishes its rule identifier; and
+- two independent `PeriodSystem` instances cannot leak conventions or factors into one
+  another.
+
+### Relation and aggregation requirements
+
+The conformance suite must show that the implementation:
+
+- rejects a join whose foreign and primary key domains differ;
+- rejects a monetary value, rate, or category used as a key;
+- checks primary-key uniqueness and declared cardinality;
+- rejects a join result declared nonnullable when the foreign key or missing policy can
+  produce `MISSING`;
+- rejects a fallback whose type differs from the target;
+- rejects a join, lookup, reduction, or aggregation whose possible missing values lack
+  an explicit policy;
+- distinguishes missing source values from an empty target group and rejects a reducer
+  without a valid empty-group policy;
+- preserves target semantics and records the new row index after a gather;
+- rejects summing a group value repeated on person rows without deduplication;
+- derives a group sum as extensive at the target subject;
+- derives a mean as intensive at the target subject while preserving the physical unit;
+- derives numeric `MIN`, `MAX`, and policy-defined `FIRST` as `STATISTIC` at the target
+  subject;
+- rejects a weighted mean with misaligned, negative under the standard rule,
+  dimensioned, or undeclared-normalization weights and checks its zero-weight policy;
+- keeps `mean_per_member()` at target subject even when broadcast to source rows;
+- derives `allocate_equal()` at source subject and verifies its declared conservation
+  and zero-count policy;
+- rejects a declaration that substitutes one of those meanings for the other;
+- derives boolean sum as a typed count of the source entity;
+- rejects a count whose counted entity is unspecified;
+- checks local axes, row axes, `where`, weights, `keepdims`, and row metadata for
+  in-body reductions;
+- distinguishes reduction over a local choice axis from aggregation over person rows;
+  and
+- rejects a reduction over an untyped axis;
+- preserves a household row grain idempotently under valid pointwise multiplication
+  instead of multiplying or cancelling a fictitious group dimension; and
+- handles zero-length sources and empty target groups according to the declared
+  identity, missing, or error policy.
+
+### Calendar requirements
+
+The conformance suite must show that:
+
+- year point minus year point returns a year duration;
+- year point plus year duration returns a year point;
+- year point plus year point is rejected;
+- quarter, month, and day ordinals reject fractional and out-of-range representations;
+- a complete date rejects an invalid day, including February 29 in a non-leap year;
+- month of year plus month duration is rejected;
+- a year-month point plus month duration wraps through years under an explicit
+  convention;
+- a date point plus month duration requires a defined end-of-month rule;
+- a calendar point cannot be compared with a duration; and
+- policy flow-period conversion is not dispatched through calendar arithmetic.
+
+### Currency requirements
+
+The conformance suite must include:
+
+- at least two statutory denominations and a changeover date;
+- parameters and inverse- and squared-currency coefficients declared in each regime's
+  concrete denomination;
+- exponent-aware conversion of ordinary amounts, inverse-currency coefficients, and
+  integer higher powers, plus rejection of a noninteger currency exponent at the
+  standard boundary;
+- typed input in one denomination converted to another computation denomination;
+- statutory rounding before output conversion and a presentation view explicitly labeled
+  as nonstatutory in the target currency;
+- a carried-value case whose origin denomination differs from the current policy
+  denomination;
+- rejection of a carried value that is silently relabeled;
+- nullable monetary input with its missing mask preserved;
+- integer monetary input that would truncate under conversion;
+- finite floating input whose exact conversion would overflow, which must fail rather
+  than become infinity silently;
+- zero-length, largest-finite, subnormal, positive- and negative-zero, NaN, and infinity
+  cases under the declared dtype and data-validity policy;
+- object-dtype rejection or a registered converter;
+- the same exact rate, exponent, and operation order in NumPy and JAX front ends; and
+- two independent `UnitSystem` instances whose registrations do not interfere.
+
+### Date-regime requirements
+
+The conformance suite must construct and validate a maximal partition with independent
+boundaries from:
+
+- a function start or end;
+- a parameter value change;
+- a parameter physical-unit, period-signature, or period-convention change with no
+  function boundary;
+- a parameter leaf-set, index, local-axis, or schedule-axis change;
+- a statutory-currency change;
+- a period-conversion rule or convention change;
+- a rounding-rule change; and
+- a relation or aggregation-schema change.
+
+For every inclusive start and end declaration used by the test fixture, the suite
+validates the exact start, the exact end, and the successor of the end when it lies in
+the supported domain. A mutation that inserts a wrong type only at a parameter-only date
+must fail. The evidence report must list the interval containing the mutation and the
+parameter boundary that created it.
+
+### Evidence and exception requirements
+
+The conformance suite must verify that:
+
+- every active node and interval has one primary evidence status;
+- a body exemption never counts as body verified;
+- `verify_units=False`, an unstructured full-type cast, and an unmanifested opt-out are
+  rejected;
+- a type assertion records inferred and asserted types;
+- an expired or unmanifested assertion or exemption fails the release gate;
+- unsupported syntax fails closed;
+- crossing a checker resource limit is visible and nonverified;
+- bare input is reported as assumed, while fully typed input is reported separately;
+- the four public claim levels are computed from evidence and cannot be selected
+  manually; and
+- coverage percentages cannot hide assertions, exemptions, unsupported bodies, trusted
+  external primitives, or untested date intervals.
+
+### Worked-example acceptance
+
+The bundled worked example must meet all of the following.
+
+1. Every active node, parameter leaf, local and schedule axis, rounding rule, join,
+   aggregation, compound field, and result has a complete resolved `TypeSpec` in every
+   maximal date interval.
+1. All ordinary body-bearing functions are `BODY_VERIFIED`; the worked example contains
+   no `DECLARED_ONLY_EXEMPTION` node.
+1. No function relabels a stock as a flow, a group total or group mean as a person
+   allocation, or an ID as a number.
+1. Parameter-only, period-convention-only, local-axis-only, currency-only, and
+   rounding-only date regimes are included.
+1. Every assertion and semantic reassignment appears in a reviewed manifest.
+1. The adversarial tests above pass for both supported NumPy and JAX execution front
+   ends.
+1. Typed and untyped boundaries return numerically identical values after expected
+   conversion, while their evidence correctly differs.
 
 ## Related work
 
-- {ref}`GEP 1 <gep-1>` defines the time and grouping suffixes validated here.
-- {ref}`GEP 2 <gep-2>` defines the `*_id` columns from which grouping levels are found.
-- {ref}`GEP 4 <gep-4>` defines the DAG, aggregations, and reference-period conversions.
+- {ref}`GEP 1 <gep-1>` defines policy-node naming conventions and generated
+  reference-period conversions.
+- {ref}`GEP 2 <gep-2>` defines grouping and identifier concepts.
+- {ref}`GEP 4 <gep-4>` defines the DAG and generated aggregation architecture.
 - {ref}`GEP 5 <gep-5>` defines rounding specifications.
-- {ref}`GEP 9 <gep-9>` defines runtime type validation and the user/canonical data
-  split.
-- [pint](https://pint.readthedocs.io) supplies the unit registry and dimensional
-  algebra.
+- {ref}`GEP 9 <gep-9>` defines runtime type checking and the user/canonical type split.
+- [Pint](https://pint.readthedocs.io/) supplies physical-unit parsing, equivalence, and
+  conversion.
+- Nominal ID and category domains follow the same principle as newtypes or branded types
+  in static type systems: equal representation does not imply substitutability.
+- The syntax-directed checker follows ordinary abstract-interpretation and typed-IR
+  practice: it is conservative over a specified language rather than an execution-based
+  test of arbitrary Python behavior.
 
 ## Implementation
 
-The implementation is divided between TTSIM infrastructure and policy-system
-annotations.
+The implementation is divided into ordered phases. A later phase must not claim
+conformance while a required earlier phase remains a permissive placeholder.
 
-- TTSIM [#138](https://github.com/ttsim-dev/ttsim/pull/138) is the open infrastructure
-  PR. It contains the registry, compositional vocabulary, dimensions, mandatory
-  declarations, aggregation validation, function-body validation, and input-boundary
-  validation.
-- TTSIM [#141](https://github.com/ttsim-dev/ttsim/pull/141) is the open worked-example
-  PR. It annotates the bundled fictional `METTSIM` policy system and validates it across
-  policy dates.
-- GETTSIM [#1193](https://github.com/ttsim-dev/gettsim/pull/1193) contains this draft
-  GEP.
-- GETTSIM [#1212](https://github.com/ttsim-dev/gettsim/pull/1212) contains the GETTSIM
-  rollout.
+### Phase 1: canonical type core
+
+- Implement immutable `ValueSpec`, `StructSpec`, `MappingSpec`, `PhysicalUnit`,
+  `PeriodSpec`, `PeriodSignature`, `PeriodConvention`, `SemanticKind`, `SubjectSpec`,
+  `IndexSpec`, `AxisSpec`, `Extensity`, `CalendarSpec`, `CurrencySpec`, and nullability.
+- Keep Pint behind the `PhysicalUnit` boundary.
+- Implement canonical serialization, equality, hashing, diagnostics, and structured YAML
+  parsing.
+- Replace process-global registration with immutable `UnitSystem` instances.
+- Implement complete constructors under `Q` and a legacy migration adapter that cannot
+  claim full verification.
+
+### Phase 2: declarations and graph resolution
+
+- Migrate decorators, policy inputs, parameters, structured fields, schedules, rounding
+  rules, and typed columns to `value_type` declarations.
+- Resolve every canonical axis before graph validation.
+- Add nominal key and category domains.
+- Represent generated period conversions with named conventions, relations, joins,
+  broadcasts, allocations, and aggregations as typed graph nodes.
+- Implement suffix consistency checks without using suffixes as the only type source.
+
+### Phase 3: typed expression interpreter
+
+- Lower the supported Python subset to a typed IR.
+- Implement syntax-directed branch analysis and return checking.
+- Create one primitive registry for scalar, vectorized, and generated operations.
+- Implement boolean truth-context checks, typed equality, typed zero and missing
+  literals, conditionals, schedules, structured access, and full operation diagnostics.
+- Reject unsupported syntax and unregistered primitives.
+
+### Phase 4: relations, axes, and aggregation
+
+- Implement `RelationSpec`, key-domain checks, uniqueness, cardinality, and missing
+  policies.
+- Implement typed gather, broadcast, subject reassignment, target-level per-member
+  statistics, equal and weighted allocation, and count scaling.
+- Implement aggregation and local-array axis semantics, including repeated-value
+  protection.
+- Require every reduction wrapper to forward all type-relevant arguments.
+
+### Phase 5: calendar and currency
+
+- Implement distinct calendar points, durations, and ordinals, plus date-aware statutory
+  period conversions that cannot be confused with standard annualized conversion.
+- Correct the types of policy and evaluation date components.
+- Implement environment-local currency families, statutory histories, provenance,
+  carried-value rules, typed coefficients, and boundary conversion ordering.
+- Implement dtype-safe numerical conversion and typed rounding regimes.
+
+### Phase 6: date partition and evidence
+
+- Implement the maximal date-partition algorithm.
+- Validate every interval and publish boundary provenance.
+- Implement evidence statuses, qualifiers, source digests, derivations, coverage,
+  assertion and exemption manifests, and the default release gate.
+
+### Phase 7: worked example and GETTSIM rollout
+
+- Migrate METTSIM without proof-erasing stock-to-flow, group-to-person, or coefficient
+  casts.
+- Run the complete conformance and adversarial suite across every date interval.
+- Migrate GETTSIM policy declarations and historical currency regimes.
+- Retain untyped input compatibility while distinguishing assumed from verified boundary
+  types.
+
+### Existing pull requests
+
+The following pull requests are prototypes for parts of the original GEP and are not, by
+their current existence alone, implementations of this revised specification.
+
+- [TTSIM #138](https://github.com/ttsim-dev/ttsim/pull/138) must replace the
+  compositional group-dimension model, permissive placeholder behavior, and
+  process-global vocabulary with the canonical value type, typed IR, relation rules,
+  evidence, and local registries above. It must in particular validate every truth
+  context, `where` condition, join argument, fallback, cardinality, reduction axis, and
+  date regime.
+- [TTSIM #141](https://github.com/ttsim-dev/ttsim/pull/141) must migrate the worked
+  example to the revised declarations, remove stock-as-monthly-flow annotations, fully
+  type coefficients and group operations, and validate the maximal date partition
+  including parameter-only changes.
+- [GETTSIM #1193](https://github.com/ttsim-dev/gettsim/pull/1193) contains the GEP
+  discussion and is the target for this text.
+- The GETTSIM rollout must not claim completion until the TTSIM infrastructure and
+  worked example pass the conformance requirements in this document.
+
+A PR may land in phases, but the public feature remains experimental until the complete
+required stack is present. Documentation and evidence must identify partial
+implementations precisely.
 
 (gep-10-alternatives)=
 
 ## Alternatives
 
-### A person level, implied or spelled
+### Encode grouping levels as Pint dimensions
 
-Rejected. Earlier drafts kept a distinct individual level `[person]`: an implied leaf on
-every individual quantity, so a per-person monthly amount resolved to
-`CURRENCY / month / [person]`, head counts were `[person] / [group]`, and the `[person]`
-dimension doubled as the count dimension. A spelled variant
-(`CURRENCY_PER_MONTH_PER_PERSON`) was considered too, for full symmetry with the group
-levels, but two spellings — the bare form and the `_PER_PERSON` form — would then denote
-the same unit, violating the one-spelling-per-unit invariant.
+Rejected. A subject or row grain is not a physical denominator. Pointwise multiplication
+of two household-indexed values would incorrectly square a household dimension, while
+division would cancel it even though the result remains household-indexed. Means,
+minima, maxima, joins, and broadcast representations also cannot be represented
+faithfully by this algebra.
 
-The adopted model removes the person level entirely: an individual quantity is simply
-bare, and a head count is dimensionless (`1 / [group]` at a group level). This is a
-deliberate simplification with a real tradeoff. A person level bought two things: a
-level-neutral rate or share (bare `dimensionless`) could be told apart from a per-person
-amount (`.../[person]`), and per-capita divisions produced a typed per-person residue
-rather than cancelling to bare. Its cost was a more complex model — an implied leaf
-whose attachment depended on an extensive-vs-intensive classification of every base, the
-`PER_PERSON` spelling duplicating a bare form, and booleans carrying `1 / [person]` at
-the individual grain.
+### Treat all nonphysical values as dimensionless
 
-### Convert all parameters to a selected run currency
+Rejected. Booleans, IDs, categories, shares, probabilities, rates, and counts support
+different operations and nominal domains. A dimensionless catch-all permits nonsense
+such as adding an ID to a tax rate or using wealth as a condition.
 
-Rejected. Some statutory formulas contain coefficients whose numerical values depend on
-the currency convention even when the statute prints them as bare numbers. The Wohngeld
-basic formula is an example:
+### Use one implied person level and group denominators
 
-```text
-1.15 * (M - (a + b*M + c*Y) * Y)
-```
+Rejected. This still conflates physical algebra with relational ownership and storage
+layout. It cannot represent a household value repeated on person rows without either
+losing the household subject or inviting double counting.
 
-If `M` and `Y` have unit currency per month, then `a` is dimensionless and `b` and `c`
-have the implicit unit "month per currency". Their numerical values must change when the
-currency unit changes. Treating `b` and `c` as dimensionless would be dimensionally
-incorrect; converting only `M` and `Y` would change the formula's result.
+### Infer meaning from node names and suffixes
 
-One possible design would declare the implicit units of every coefficient and rescale
-each coefficient when the computation currency changes. This would be dimensionally
-complete but would add declarations that are not explicit in the statutory source and
-would require conversion rules for heterogeneous structured parameters and polynomial
-coefficients.
+Rejected as the primary type source. Suffixes are valuable redundant checks but do not
+encode semantic kind, extensity, key domain, nullability, representation, join
+cardinality, calendar kind, coefficient units, or currency provenance.
 
-The adopted design instead evaluates every formula in its statutory currency. Parameters
-and coefficients retain their statutory numerical values. Only input data and computed
-results cross the currency boundary.
+### Execute functions on placeholder quantities and call the result verified
 
-### Pass Pint quantities through the DAG
+Rejected as the specification model. Placeholder execution can be a useful
+implementation aid, but path choices, hand-written stand-ins, Python truth semantics,
+unsupported operations, and bounded exploration make it unsuitable as the assurance
+contract. The adopted design specifies a syntax-directed typed interpreter and publishes
+unsupported code explicitly.
 
-Rejected. `pint.Quantity` is not a JAX pytree and cannot be used in the compiled JAX
-calculation. Units are static properties of nodes, so environment and boundary
-validation provide the required checks without changing the numerical representation
-inside the TT function.
+### Leave equality unchecked
 
-### Remove currency labels for parameters
+Rejected. The legacy missing-ID use case is handled by typed optional identifiers and
+missing sentinels. Blanket equality exemption would allow monthly and annual amounts or
+unrelated ID domains to compare silently.
 
-Rejected. Concrete currency labels in parameter YAMLs seem redundant because we don't
-allow for any other currency than the statutory one at a given policy date (i.e. you
-can't pass a EUR parameter to a DM policy date). However, the labels are useful for
-validation and for human readers. During implementation it proved to be helpful to
-receive automatic validation errors when a parameter is declared in the wrong currency.
-Adding concrete currency tags does not demand much work from developers and helps to
-prevent painful conversion bugs.
+### Let `where`, joins, and reductions preserve the result-arm or target unit
+
+Rejected. Conditions, keys, domains, cardinality, fallbacks, axes, uniqueness, and
+extensity are part of the operation's correctness. Ignoring them creates ordinary false
+negatives.
+
+### Use generic casts and whole-body opt-outs
+
+Rejected as the normal workflow. Typed literals, relation-mediated alignment, subject
+reassignment, allocation, calendar construction, and registered primitives cover
+distinct valid cases. A last-resort assertion or exemption remains available but carries
+structured evidence and never counts as verified.
+
+### Convert every statutory parameter into the caller's data currency
+
+Rejected. Legally rounded changeover values and currency-dependent coefficients must
+retain their statutory numerical representation. The adopted design computes in the
+statutory denomination, while requiring complete units for coefficients and explicit
+conversion at data boundaries.
+
+### Omit units for coefficients not printed with units in statutes
+
+Rejected. Mathematical dimensionality follows from the formula, not typography. An
+inverse-income coefficient must declare the inverse unit and period required to make the
+formula well typed.
+
+### Pass Pint quantities through the compiled DAG
+
+Rejected. Static `ValueSpec` metadata and boundary conversion provide the intended
+validation without placing Pint objects inside JAX traces or changing runtime array
+representation.
+
+### Treat month of year and day of month as affine points
+
+Rejected. They are cyclic or contextual ordinals. Valid affine arithmetic requires a
+year-month or complete date point and an explicit wrap or end-of-month convention.
+
+### Validate only dates where functions start or stop
+
+Rejected. Parameters, leaf schemas, currencies, rounding, schedules, and relations can
+change while the same functions remain active. The maximal partition is required.
+
+### Report a single annotation-coverage percentage
+
+Rejected. Declaration coverage, body verification, generated-rule derivation,
+assertions, exemptions, assumed inputs, unsupported bodies, and date coverage convey
+different evidence and must remain separate.
 
 ## Discussion
 
-- [GETTSIM #1193: GEP 10 — Units and Dimensionality](https://github.com/ttsim-dev/gettsim/pull/1193)
-- [TTSIM #138: units and dimensionality infrastructure](https://github.com/ttsim-dev/ttsim/pull/138)
+- [GETTSIM #1193: GEP 10 discussion](https://github.com/ttsim-dev/gettsim/pull/1193)
+- [TTSIM #138: original infrastructure prototype](https://github.com/ttsim-dev/ttsim/pull/138)
+- [TTSIM #141: original METTSIM worked-example prototype](https://github.com/ttsim-dev/ttsim/pull/141)
 
 ## References and footnotes
 
-- [GETTSIM #1174: discussion of Deutsche-Mark values](https://github.com/ttsim-dev/gettsim/issues/1174)
-- [pint](https://pint.readthedocs.io)
+- [Pint documentation](https://pint.readthedocs.io/)
+- [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119)
+- [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174)
 - [NEP 18: NumPy array-function protocol](https://numpy.org/neps/nep-0018-array-function-protocol.html)
 
 ## Copyright

--- a/docs/geps/gep-10.md
+++ b/docs/geps/gep-10.md
@@ -6,7 +6,7 @@
 - * Author
   * [Marvin Immesberger](https://github.com/MImmesberger)
 - * Status
-  * Draft
+  * Accepted
 - * Type
   * Standards Track
 - * Created
@@ -27,9 +27,10 @@ example, it can distinguish:
 - total rent from rent per square meter; and
 - a household total from a total for a Bedarfsgemeinschaft.
 
-TTSIM uses these declarations to review the unit calculations in a policy environment.
-When it assembles the environment, it runs supported policy formulas with test values
-that carry units. It rejects operations that do not make sense, such as adding a monthly
+TTSIM uses these declarations to review the unit calculations in a policy environment,
+meaning the functions and parameters that apply on a particular policy date. When TTSIM
+assembles this environment, it runs supported policy formulas with test values that
+carry units. It rejects operations that do not make sense, such as adding a monthly
 amount to an annual amount or using an amount of money as the condition in an `if`
 statement.
 
@@ -39,9 +40,9 @@ dimensionless number has the right economic meaning. A share, an identifier, a c
 code, and a count are all dimensionless in the physical sense. The checker can
 distinguish them only in the special cases described in this GEP. Likewise, a household
 marker helps with selected calculations involving household totals and head counts, but
-it does not replace checks of data layout, merge keys, or group membership. If TTSIM
-does not know how an operation affects units, it must reject the operation or record an
-explicit exception.
+it does not fully describe the variable's grain and does not replace checks of data
+layout, merge keys, or group membership. If TTSIM does not know how an operation affects
+units, it must reject the operation or record an explicit exception.
 
 The unit declarations also set one rule for historical currencies. Each policy regime is
 calculated in the currency used by the law in that regime. GETTSIM converts monetary
@@ -66,10 +67,12 @@ This GEP addresses four recurring sources of mistakes.
    `float` column may contain wealth, monthly earnings, annual earnings, a share, or
    square meters. Python, NumPy, and JAX normally allow arithmetic between these columns
    even when the economic quantities are not compatible.
-1. **Group calculations can use the wrong level.** A household total can accidentally be
-   combined with a Bedarfsgemeinschaft total. A formula can also forget to divide a
-   group total by the number of people in the group. These mistakes are similar to using
-   a variable produced by `egen total(), by(hh_id)` as if it were a person-level value.
+1. **Group calculations can use the wrong grain.** Grain is the level at which a
+   variable is defined or varies, such as person, household, or Bedarfsgemeinschaft. A
+   household total can accidentally be combined with a Bedarfsgemeinschaft total. A
+   formula can also forget to divide a group total by the number of people in the group.
+   These mistakes are similar to using a variable produced by `egen total(), by(hh_id)`
+   as if it were a person-level value.
 1. **Historical policy parameters use different currencies.** German statutes contain
    both Deutsche-Mark and Euro amounts. Rewriting all historical values into one
    currency would obscure the values stated in the law and can change formulas that
@@ -83,10 +86,11 @@ Python library for calculations with units, and covers:
 
 - physical units, reference periods, and a limited set of group markers built with Pint;
 - unit declarations for policy functions, inputs, parameters, schedules, structured
-  values, generated nodes, aggregations, rounding rules, and optionally tagged input
-  data;
+  values, automatically generated calculations, aggregations, rounding rules, and
+  optionally unit-annotated input data;
 - checking the supported expressions inside policy functions;
-- explicit rules for conditions, `xnp.where`, joins, and reductions;
+- explicit rules for conditions, `xnp.where` (an array-valued if-then-else), joins
+  (merges), and reductions such as sums over arrays;
 - checking every relevant combination of functions, parameters, and statutory currency;
 - one statutory computation currency in each policy regime; and
 - separate reporting of inferred units, generated rules, local unit assertions, and
@@ -99,16 +103,18 @@ The GEP does **not** check:
   probabilities, categories, counts, and rates;
 - whether merge keys refer to the same kind of identifier, are unique, or produce the
   intended number of matches;
-- whether columns have the intended observations, sorting, alignment, or broadcasting;
+- whether columns contain the intended observations, are sorted and aligned correctly,
+  or are automatically repeated across rows or array dimensions;
 - numerical stability, finite values, overflow, or economically sensible ranges;
 - arbitrary Python or third-party functions for which TTSIM has no unit rule; or
 - legal conventions for day counts, partial periods, and compounding beyond the existing
   automatic period conversions.
 
 The naming rules and automatic period conversions in {ref}`GEP 1 <gep-1>`, group
-identifiers in {ref}`GEP 2 <gep-2>`, calculation-graph (DAG) and aggregation concepts in
-{ref}`GEP 4 <gep-4>`, rounding in {ref}`GEP 5 <gep-5>`, and runtime data types in
-{ref}`GEP 9 <gep-9>` continue to apply.
+identifiers in {ref}`GEP 2 <gep-2>`, the map of how calculations depend on one another
+and the aggregation concepts in {ref}`GEP 4 <gep-4>`, rounding in {ref}`GEP 5 <gep-5>`,
+and the checks applied to values when the model runs in {ref}`GEP 9 <gep-9>` continue to
+apply.
 
 (gep-10-guarantee)=
 
@@ -131,10 +137,11 @@ Documentation and continuous-integration output MUST report at least:
 
 - declarations that were found and resolved;
 - policy-function bodies that were checked;
-- automatically generated nodes whose units follow a documented rule;
+- automatically generated calculations whose units follow a documented rule;
 - local uses of `cast_ttsim_unit`;
-- bodies excluded with `verify_units=False`; and
-- bodies that could not be checked because they use an unsupported operation.
+- bodies excluded with `verify_units=False`;
+- bodies rejected because they use an unsupported operation; and
+- any other function bodies that were not checked, together with the reason.
 
 (gep-10-usage)=
 
@@ -174,8 +181,9 @@ policy regime, a policy function does not receive a mixture of DM and EUR amount
 ### Unit-annotated data
 
 Users may optionally attach a unit to every input column. This is useful when a dataset
-comes with a known currency and reference period. In this input mode, every leaf is a
-`UnitAnnotatedColumn`, including identifiers and other dimensionless columns.
+comes with a known currency and reference period. In this input mode, every final entry
+in the nested input (called a leaf in the code) is a `UnitAnnotatedColumn`, including
+identifiers and other dimensionless columns.
 
 ```python
 from gettsim import InputData, MainTarget, TTTargets, main
@@ -208,20 +216,21 @@ results = main(
 )
 ```
 
-The limits of the first implementation MUST be described exactly. It performs the
-following checks at the data boundary:
+The data-boundary checks MUST be described exactly. They verify that:
 
 - an unknown unit name is an error;
-- the period in the unit MUST agree exactly with the GEP-1 suffix of the column name;
-- a stated source currency may differ from the statutory currency and is converted; and
-- other physical dimensions and group levels are not yet compared with the unit declared
-  for the policy node.
+- the period in the unit agrees exactly with the GEP-1 suffix of the column name;
+- the tag and the policy declaration agree on whether the value is monetary, on its
+  remaining physical measure and scale, and on its group marker; and
+- a stated source currency may differ from the statutory currency and is converted
+  before the policy calculation.
 
-For example, a column ending in `_m` but tagged as an annual flow is rejected. The
-boundary check alone does not detect that an age column was accidentally tagged as
-currency. The declarations on policy inputs and functions remain the authoritative units
-used in the calculation. In this version, tagged input protects currency and period; it
-is not a complete variable-dictionary check.
+For example, TTSIM rejects a column ending in `_m` that is tagged as an annual flow, an
+age column tagged as currency, and a household amount tagged as a person-level amount.
+The policy declaration remains authoritative; the input tag must agree with it except
+for an allowed currency conversion. These checks establish consistency of the stated
+units. They do not establish that a dimensionless value has the intended economic
+meaning or that observations are matched to the right people and groups.
 
 When users request `MainTarget.results.tree_with_unit_annotations`, calculated results
 include their resolved unit and output currency. The ordinary result targets continue to
@@ -360,9 +369,10 @@ regime.
   it as unchecked. It MUST NOT count as a checked body.
 - `cast_ttsim_unit` remains available for a local unit assertion. The report lists each
   use separately from units inferred by TTSIM.
-- Unit validation cannot be switched off for an entire policy environment.
-  `include_fail_nodes=False` may skip selected failure nodes while the environment or
-  tagged input is processed, but invalid declarations are still errors.
+- Unit checks are normally included when a policy environment is assembled. When
+  explicit output targets are supplied, `include_fail_nodes=False` can omit unit-related
+  failure checks from that call. Results from such a call MUST NOT be described as
+  unit-validated, even though some invalid declarations may still be rejected earlier.
 
 ## Detailed description
 
@@ -373,16 +383,16 @@ regime.
 1. **Use Pint for ordinary unit arithmetic.** Pint handles physical units and reference
    periods. TTSIM adds only the policy-specific rules described here.
 1. **Use group markers for selected group calculations.** They help find mistakes in
-   totals, head counts, and indicators. They do not describe every aspect of the data's
-   observation level.
+   totals, head counts, and indicators at different grains. They do not fully describe a
+   variable's grain or the layout of the data.
 1. **Describe the check accurately.** TTSIM checks a defined set of expressions. It does
    not prove arbitrary Python code correct.
 1. **Check every relevant argument.** If a condition, fallback value, key, period, or
    other argument can affect the unit of a supported operation, the checker MUST inspect
    it.
-1. **Reject unsupported changes of observation level.** If an operation may change what
-   a row represents and TTSIM lacks the necessary array or grouping information, the
-   checker must not simply keep the old unit.
+1. **Reject unsupported changes of grain.** If an operation may change the level at
+   which a result is defined and TTSIM lacks the necessary array or grouping
+   information, the checker must not simply keep the old unit.
 1. **Check every distinct policy regime.** A regime may change because a function,
    parameter, rounding rule, or statutory currency changes.
 1. **Keep exceptions visible.** A declaration, a generated rule, a checked body, a local
@@ -395,24 +405,26 @@ regime.
 
 ### Terminology
 
-| Term               | Meaning                                                                                                                                                                             |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| quantity           | A value with a unit, such as income, age, a share, or a head count.                                                                                                                 |
-| base               | What is measured in the numerator, such as `CURRENCY`, `DIMENSIONLESS`, or `YEARS`.                                                                                                 |
-| period             | A denominator such as `MONTH` or `YEAR` that identifies a flow or rate.                                                                                                             |
-| grouping level     | A denominator such as `HH` or `BG` that marks selected amounts, counts, or indicators belonging to that group. It is not a complete description of the dataset's observation level. |
-| bare               | A quantity without a grouping denominator. Person-level quantities and ordinary shares or rates are usually bare.                                                                   |
-| stock              | A quantity without a period denominator, such as wealth.                                                                                                                            |
-| flow               | A quantity with a period denominator, such as monthly income.                                                                                                                       |
-| rate               | A multiplier. A rate that converts a stock to a flow has a period denominator.                                                                                                      |
-| calendar point     | A location on a calendar, such as the year 2025.                                                                                                                                    |
-| calendar ordinal   | A position within a larger calendar unit, such as month 2 or day 15.                                                                                                                |
-| calendar duration  | A length of time, such as 18 years or 3 months.                                                                                                                                     |
-| statutory currency | The currency in which the law states the active parameters and rounding rules.                                                                                                      |
-| data currency      | The currency assumed for untagged input and requested for calculated output.                                                                                                        |
-| body check         | Running supported policy formulas with unit-carrying test values and comparing the result with the declared unit.                                                                   |
-| cast               | A local assertion that tells the checker to use a stated unit for one expression.                                                                                                   |
-| opt-out            | `verify_units=False` on one function. Its output declaration still applies, but its calculations are not checked.                                                                   |
+| Term               | Meaning                                                                                                                                             |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| quantity           | A value with a unit, such as income, age, a share, or a head count.                                                                                 |
+| base               | What is measured in the numerator, such as `CURRENCY`, `DIMENSIONLESS`, or `YEARS`.                                                                 |
+| period             | A denominator such as `MONTH` or `YEAR` that identifies a flow or rate.                                                                             |
+| grain              | The level at which a variable is defined or varies, such as person, household, or Bedarfsgemeinschaft.                                              |
+| group marker       | A denominator such as `HH` or `BG` that checks selected amounts, counts, or indicators at that grain. It is not a complete representation of grain. |
+| stock              | A quantity without a period denominator, such as wealth.                                                                                            |
+| flow               | A quantity with a period denominator, such as monthly income.                                                                                       |
+| rate               | A multiplier. A rate that converts a stock to a flow has a period denominator.                                                                      |
+| calendar point     | A location on a calendar, such as the year 2025.                                                                                                    |
+| calendar ordinal   | A position within a larger calendar unit, such as month 2 or day 15.                                                                                |
+| calendar duration  | A length of time, such as 18 years or 3 months.                                                                                                     |
+| statutory currency | The currency in which the law states the active parameters and rounding rules.                                                                      |
+| data currency      | The currency assumed for untagged input and requested for calculated output.                                                                        |
+| policy environment | The functions, inputs, parameters, and automatically generated calculations that apply on one policy date.                                          |
+| leaf               | A final value in a nested input or parameter structure, rather than a dictionary containing further entries.                                        |
+| body check         | Running supported policy formulas with unit-carrying test values and comparing the result with the declared unit.                                   |
+| cast               | A local assertion that tells the checker to use a stated unit for one expression.                                                                   |
+| opt-out            | `verify_units=False` on one function. Its output declaration still applies, but its calculations are not checked.                                   |
 
 (gep-10-valuespec)=
 
@@ -501,7 +513,12 @@ require a separate system for economic meaning and data relations.
 
 (gep-10-levels)=
 
-### Grouping levels
+### Grain and group markers
+
+In this GEP, **grain** is the level at which a variable is defined or varies. Examples
+are person, household, family unit, Bedarfsgemeinschaft, and tax unit. Grain is distinct
+from a physical unit. GEP 10 nevertheless uses group markers as a limited check for
+selected calculations across grains.
 
 GETTSIM stores one row per person and identifies that person with `p_id`. Columns such
 as `hh_id`, `fg_id`, `bg_id`, `sn_id`, `eg_id`, `ehe_id`, and `wthh_id` identify groups.
@@ -514,7 +531,8 @@ There is no `PER_PERSON` component: a person-level amount has no group denominat
 
 #### What a group marker means
 
-A group marker may be used when a value is:
+A group marker is a limited check on grain; it is not the grain itself. A group marker
+may be used when a value is:
 
 1. calculated or assigned for a particular target group; and
 1. an amount, count, or yes/no indicator for which the group calculations below make
@@ -539,29 +557,32 @@ all household members does not turn the share into a household total. GEP 10 doe
 check whether such repeated values are aligned with the correct rows.
 
 Declaration validation MUST enforce the following restriction. A direct
-`DIMENSIONLESS.PER_<LEVEL>` declaration is allowed only for a function or generated node
-known to return a count or a Boolean indicator. TTSIM learns this from the return type
-or from a generated `COUNT`, Boolean `SUM`, `ANY`, or `ALL` operation. A share,
-probability, or ordinary rate with a group marker is rejected. If TTSIM cannot tell
-whether a physically dimensionless group value is a count or indicator, it MUST reject
-the declaration rather than guess.
+`DIMENSIONLESS.PER_<LEVEL>` declaration is allowed only for a count or yes/no indicator
+whose meaning is established independently of its unit. Generated `COUNT`, the sum of a
+yes/no indicator, `ANY`, and `ALL` qualify automatically. A directly declared integer
+value may qualify as a count when the function documents that interpretation, although
+an integer return type alone does not distinguish a count from an identifier or category
+code. A floating-point share, probability, or ordinary rate with a group marker is
+rejected. If TTSIM cannot establish one of the permitted cases, it MUST reject the
+declaration rather than guess.
 
 #### Restricted group calculations
 
 TTSIM checks the following group calculations:
 
-1. Multiplying or dividing a group quantity by an ordinary dimensionless scalar keeps
-   the group marker.
+1. Multiplying or dividing a group quantity by a quantity that has no group marker
+   follows ordinary unit arithmetic and keeps the group marker. For example, multiplying
+   group wealth by an annual interest rate produces an annual group flow.
 1. Dividing a group total by the matching group head count removes the group marker and
    gives a person-level amount.
 1. Multiplying a person-level amount by the matching group head count adds the group
    marker and gives a group total.
-1. Logical operations follow the rules in
-   {ref}`Conditions and Boolean values <gep-10-booleans>`. A known Boolean indicator may
-   select or mask a value at the same group level in a conditional expression or
-   `xnp.where`; its group marker is not multiplied into the selected value. Direct
-   multiplication receives this special mask rule only when the producer is known to be
-   Boolean.
+1. Logical operations follow the rules in {ref}`Conditions <gep-10-booleans>`. A yes/no
+   indicator whose meaning is known from the operation that produced it may select or
+   mask a value at the same group level in a conditional expression or `xnp.where`; its
+   group marker is not multiplied into the selected value. Direct multiplication
+   receives this special mask rule only when the value is independently known to be a
+   yes/no indicator.
 1. Other multiplication or division between two non-count group quantities is rejected.
    This avoids results such as “household squared” and accidental cancellation between
    unrelated group properties.
@@ -592,48 +613,6 @@ familie__anzahl_personen_sn * sparerfreibetrag_y
 If a policy deliberately transfers an amount from one group concept to another, the
 function must use a local cast or an explicitly declared aggregation. TTSIM does not
 infer how households, Bedarfsgemeinschaften, tax units, and other groups overlap.
-
-(gep-10-booleans)=
-
-### Conditions and Boolean values
-
-A condition in a policy formula should represent a yes/no statement. A monthly amount,
-age, or annual rate is not a valid condition merely because Python can treat a non-zero
-number as `True`.
-
-Because several meanings share `DIMENSIONLESS`, the unit checker applies a narrower rule
-called **truth compatibility**. A value is truth-compatible if it has no physical unit
-and no period, and has at most one permitted group marker. Python annotations and
-runtime validation still determine whether the actual value is a Boolean rather than an
-identifier, count, or share.
-
-The same truth-compatibility rule MUST apply to:
-
-- Python `if` statements and conditional expressions;
-- `bool(value)` calls made while branches are checked;
-- supported uses of `not`, `&`, `|`, `^`, and `~`; and
-- the `condition` argument of `xnp.where`.
-
-The following function is invalid because `wealth` is an amount of money, not a
-condition:
-
-```python
-@policy_function(unit=TTSIMUnit.CURRENCY)
-def invalid(wealth: float) -> float:
-    return wealth if wealth else 0.0
-```
-
-`xnp.where` MUST check the condition as well as the two possible results. Rewriting a
-scalar conditional as a vectorized `xnp.where` must not remove this check.
-
-When two logical inputs carry the same group marker, the result keeps that marker. If
-one is person-level and one is group-level, or if their group levels differ, the result
-is treated as person-level because the logical operation is evaluated row by row. This
-is a practical unit rule; it does not establish that the underlying rows are aligned.
-
-Ordering comparisons such as `<` and `>=` require compatible units and produce a
-truth-compatible result. Equality comparisons do not compare units, for the reasons
-given in {ref}`Trade-offs and limitations <gep-10-limitations>`.
 
 (gep-10-hours)=
 
@@ -666,9 +645,9 @@ supported calculations are:
 
 Quarter of year, month of year, and day of month are positions within a larger calendar
 unit. For example, `2 CALENDAR_MONTH` means February and `15 CALENDAR_DAY` means the
-fifteenth day of a month. TTSIM supplies specific checking rules for these values rather
-than treating them as ordinary Pint units. They may be compared with values on the same
-calendar scale, but they do not support general addition and subtraction with durations.
+fifteenth day of a month. This GEP treats these values as **ordinals**: they may be
+compared with values on the same calendar scale, but they do not support general
+addition and subtraction with durations.
 
 In particular, the unit system does not assign a meaning to:
 
@@ -678,10 +657,13 @@ December + 2 months
 February 29 without a year and calendar
 ```
 
-Framework values such as `policy_quarter`, `policy_month`, and `policy_day` MAY remain
-dimensionless ordinals. This GEP does not check their complete calendar meaning. A later
-calendar proposal may add ranges and calendar context without changing the physical unit
-system defined here.
+The current implementation still represents framework values such as `policy_quarter`,
+`policy_month`, and `policy_day` as dimensionless numbers. This is a temporary
+implementation limitation, not a different calendar model: a successful unit check does
+not certify their ranges or their complete calendar meaning, and it does not permit the
+arithmetic ruled out above. Before full conformance, TTSIM must apply the ordinal rules
+stated here consistently. A later calendar proposal may add ranges and calendar context
+without changing the physical unit system defined here.
 
 Converting an annual flow into a monthly flow is separate from calendar arithmetic.
 `CURRENCY_PER_YEAR` to `CURRENCY_PER_MONTH` uses a reference-period ratio; it does not
@@ -752,16 +734,17 @@ freibetrag_bei_behinderung_gestaffelt_y:
   # Intervals omitted.
 ```
 
-For a parameter type that requires `input_unit:` and `output_unit:`, the schema rejects
-a single `unit:` declaration. A time suffix in the parameter name describes the output
-and must agree with `output_unit`.
+For a parameter type that requires `input_unit:` and `output_unit:`, the file-format
+rules reject a single `unit:` declaration. A time suffix in the parameter name describes
+the output and must agree with `output_unit`.
 
 #### Parameter functions
 
 A `@param_function` converts a raw YAML parameter of type `require_converter` into the
 object used by policy functions. Its declaration describes the converted object.
 
-A parameter function that produces a schedule declares both axes:
+A parameter function that produces a schedule declares the unit of the schedule's input
+and output:
 
 ```python
 @param_function(
@@ -769,13 +752,17 @@ A parameter function that produces a schedule declares both axes:
         input_unit=TTSIMUnit.CURRENCY.PER_YEAR,
         output_unit=TTSIMUnit.CURRENCY.PER_YEAR,
     ),
+    verify_units=False,
 )
 def tarif() -> PiecewisePolynomialParamValue: ...
 ```
 
-For every supported `look_up` or `piecewise_polynomial` call, TTSIM checks the unit of
-the input variable against the schedule's input unit and assigns the declared output
-unit to the result.
+The explicit opt-out applies to the code that constructs the schedule object, which is
+not an ordinary numerical policy formula. It does not remove the schedule's unit
+contract: for every supported `look_up` or `piecewise_polynomial` call, TTSIM checks the
+input variable against the schedule's input unit and assigns the declared output unit to
+the result. The construction body is nevertheless listed as unchecked in the validation
+report.
 
 A structured parameter may use `unit=UNSET_UNIT` only when the object as a whole has no
 single unit and every field that carries a quantity has its own annotation.
@@ -798,16 +785,20 @@ class SatzMitAltersgrenzen:
 def satz_mit_altersgrenzen() -> SatzMitAltersgrenzen: ...
 ```
 
-When a policy function reads an annotated scalar field, the body checker uses that
-field's unit. If a YAML leaf and an annotated field have the same path, validation
-compares their declarations. TTSIM cannot make this automatic comparison for fields that
-were renamed or derived from other fields.
+When a policy function reads an annotated scalar field, the body checker uses the unit
+stated on that field. The unit on the corresponding YAML value serves a different
+purpose: it describes the raw input to the parameter conversion and controls any
+currency conversion before that conversion takes place. TTSIM does not automatically
+prove that the parameter-conversion function maps each raw YAML value into an output
+field with the intended unit, even when the names coincide, because such a function may
+deliberately rename or transform values. That mapping therefore remains a matter for
+focused tests and policy review.
 
 (gep-10-generated)=
 
 (gep-10-auto)=
 
-### Automatically generated nodes and aggregations
+### Automatically generated calculations and aggregations
 
 #### Reference-period conversions
 
@@ -840,28 +831,31 @@ An aggregation changes the level represented by a value, much like `egen` with a
 option in Stata. TTSIM derives the result unit from the source unit, aggregation type,
 and target level.
 
-| Aggregation            | Quantity being measured          | Level of the result                                 |
-| ---------------------- | -------------------------------- | --------------------------------------------------- |
-| `SUM` of a non-Boolean | same as the source               | target group; person-level for an individual target |
-| `MIN`, `MAX`, `MEAN`   | same as the source               | target group; person-level for an individual target |
-| `COUNT`                | `DIMENSIONLESS`                  | target group; person-level for an individual target |
-| `SUM` of a Boolean     | `DIMENSIONLESS` count            | target group; person-level for an individual target |
-| `ANY`, `ALL`           | truth-compatible `DIMENSIONLESS` | target group; person-level for an individual target |
+| Aggregation                 | Quantity being measured       | Level of the result                                 |
+| --------------------------- | ----------------------------- | --------------------------------------------------- |
+| `SUM` of a non-Boolean      | same as the source            | target group; person-level for an individual target |
+| `MIN`, `MAX`, `MEAN`        | same as the source            | target group; person-level for an individual target |
+| `COUNT`                     | `DIMENSIONLESS`               | target group; person-level for an individual target |
+| `SUM` of a yes/no indicator | `DIMENSIONLESS` count         | target group; person-level for an individual target |
+| `ANY`, `ALL`                | `DIMENSIONLESS` yes/no result | target group; person-level for an individual target |
 
-A group mean remains a statistic of that group. For example, mean household wealth is a
-household-level result, even though one could write a separate formula that divides
-household total wealth by the household head count. To create a person-level allocation
-or per-person amount, use an explicit total-over-head-count calculation or aggregate to
-an individual target.
+A group mean remains a statistic of that group. For example, a generated `MEAN` of
+person-level wealth calculated separately for each household is a household-level
+result. Its numerical value may equal household total wealth divided by the household
+head count, but the two operations express different interpretations in this GEP: `MEAN`
+produces a household statistic, whereas an explicit total-over-head-count calculation
+produces a per-person amount. Use the latter, or aggregate to an individual target, only
+when the policy intends a per-person allocation.
 
 The same applies to `MIN` and `MAX`: the minimum or maximum is a property of the target
 group. The current unit system records the quantity, period, and group level. It does
 not otherwise distinguish a total, mean, minimum, and maximum once produced.
 
 A hand-written aggregation declares its result unit. The declaration MUST equal the unit
-derived from the source, aggregation type, and target level. If a policy intentionally
-interprets the result differently, it must use a local cast or `verify_units=False`, and
-the report records that exception.
+derived from the source, aggregation type, and target level. If the standard rule does
+not express the intended interpretation, the aggregation must use `verify_units=False`.
+A later policy function may use a local cast for the smallest affected expression. The
+report records either exception.
 
 `@agg_by_p_id_function` assigns results to individual people and therefore has no group
 denominator. Group identifiers themselves remain `DIMENSIONLESS`; checking whether two
@@ -879,9 +873,9 @@ A supported `join` receives checks similar to a limited review of a Stata `merge
 - the joined result has the unit of the target variable.
 
 These checks do not show that the two keys identify the same kind of entity, that the
-primary key is unique, that the merge has the intended cardinality, or that the source
-and destination rows are correct. Existing data and relation checks remain responsible
-for these properties.
+primary key is unique, that the merge has the intended number of matches, or that the
+source and destination rows are correct. Existing data and relation checks remain
+responsible for these properties.
 
 TTSIM's checking implementation of a join must inspect the keys and the fallback. If a
 new join option can affect units and TTSIM has no rule for it, the checker must reject
@@ -909,20 +903,20 @@ lacks enough information to certify their result level.
 
 #### Declaration matrix
 
-| Object                               | Required declaration                  | Currency                         | What TTSIM checks                                      |
-| ------------------------------------ | ------------------------------------- | -------------------------------- | ------------------------------------------------------ |
-| `@policy_function`                   | `unit=`                               | abstract `CURRENCY` for money    | declaration, suffixes, and supported cases in the body |
-| `@policy_input`                      | `unit=`                               | abstract `CURRENCY` for money    | declaration and suffixes                               |
-| scalar or dictionary parameter       | `unit:`                               | concrete currency for money      | schema, suffix, and statutory currency                 |
-| schedule or lookup parameter         | `input_unit:` and `output_unit:`      | concrete currency where relevant | schema and both units                                  |
-| structured `@param_function`         | `unit=UNSET_UNIT`                     | units on fields                  | field use and matching YAML leaves                     |
-| schedule-producing `@param_function` | `InputOutputUnits(...)`               | abstract `CURRENCY` in code      | schedule calls                                         |
-| generated period conversion          | automatic                             | inherited                        | target period from the suffix                          |
-| generated aggregation                | automatic                             | inherited                        | aggregation rule and target level                      |
-| hand-written aggregation             | `unit=`                               | abstract `CURRENCY` in code      | exact derived unit unless opted out                    |
-| group-creation function              | required or generated `DIMENSIONLESS` | not applicable                   | declaration only                                       |
-| rounding specification               | unit required for monetary magnitudes | concrete currency                | function unit and statutory currency                   |
-| unit-annotated input                 | unit on every leaf in this mode       | concrete source currency         | known unit, suffix period, and currency conversion     |
+| Object                               | Required declaration                             | Currency                         | What TTSIM checks                                                                            |
+| ------------------------------------ | ------------------------------------------------ | -------------------------------- | -------------------------------------------------------------------------------------------- |
+| `@policy_function`                   | `unit=`                                          | abstract `CURRENCY` for money    | declaration, suffixes, and supported cases in the body                                       |
+| `@policy_input`                      | `unit=`                                          | abstract `CURRENCY` for money    | declaration and suffixes                                                                     |
+| scalar or dictionary parameter       | `unit:`                                          | concrete currency for money      | file format, suffix, and statutory currency                                                  |
+| schedule or lookup parameter         | `input_unit:` and `output_unit:`                 | concrete currency where relevant | file format and both units                                                                   |
+| structured `@param_function`         | `unit=UNSET_UNIT`                                | units on fields                  | field use and matching YAML leaves                                                           |
+| schedule-producing `@param_function` | `InputOutputUnits(...)` and `verify_units=False` | abstract `CURRENCY` in code      | input and output units at schedule calls                                                     |
+| generated period conversion          | automatic                                        | inherited                        | target period from the suffix                                                                |
+| generated aggregation                | automatic                                        | inherited                        | aggregation rule and target level                                                            |
+| hand-written aggregation             | `unit=`                                          | abstract `CURRENCY` in code      | exact derived unit unless opted out                                                          |
+| group-creation function              | required or generated `DIMENSIONLESS`            | not applicable                   | declaration only                                                                             |
+| rounding specification               | unit required for monetary magnitudes            | concrete currency                | function unit and statutory currency                                                         |
+| unit-annotated input                 | unit on every leaf in this mode                  | concrete source currency         | known unit, suffix period, physical measure and scale, group marker, and currency conversion |
 
 `UNSET_UNIT` is only for a structured result that has no single unit. For ordinary
 parameters, functions, and aggregations, a missing unit declaration is an error.
@@ -974,10 +968,10 @@ calendar point. Runtime typing and policy review remain responsible for those me
 ### Missing values and nullability
 
 Missingness is not a physical unit. This GEP does not replace the GEP-9 rules for
-nullable values, sentinel values, or backend-specific missing-value representations. For
-a join, the checker tests whether a missing-key fallback has a unit compatible with the
-joined value. It does not establish that a particular number is a valid missing code for
-an identifier.
+nullable values, sentinel values, or the different missing-value representations used by
+NumPy and JAX. For a join, the checker tests whether a missing-key fallback has a unit
+compatible with the joined value. It does not establish that a particular number is a
+valid missing code for an identifier.
 
 For example, `NaN` or `-1` does not gain a missing-value meaning merely because it is
 `DIMENSIONLESS`. Policy packages continue to define and validate their missing-value
@@ -989,7 +983,7 @@ conventions.
 
 ### Currency
 
-#### Currency registry and statutory currency
+#### Supported currencies and statutory currency
 
 A policy package creates one `UnitSystem` with its supported currencies and the dates on
 which each currency is statutory. GETTSIM uses Euro as the base currency and defines
@@ -1114,17 +1108,19 @@ rounding.
 
 #### When checks take place
 
-| Stage                         | When                                                  | What is checked                                                                                |
-| ----------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| declaration validation        | when a function is decorated or parameters are loaded | required declarations, valid unit names, suffixes, and permitted currencies                    |
-| environment validation        | when a policy environment is assembled                | all required units, generated aggregation units, statutory currency, and complete date regimes |
-| policy-body checking          | when a policy environment is assembled                | supported calculations and every examined return case                                          |
-| tagged-input boundary         | when user input is prepared                           | known unit names, exact period suffixes, and source-currency conversion                        |
-| numerical currency conversion | immediately before and after policy calculation       | input into statutory currency and calculated output into data currency                         |
+| Stage                         | When                                                  | What is checked                                                                                                   |
+| ----------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| declaration validation        | when a function is decorated or parameters are loaded | required declarations, valid unit names, suffixes, and permitted currencies                                       |
+| environment validation        | when a policy environment is assembled for one date   | all required units, units of automatically generated aggregations, and the statutory currency for that date       |
+| policy-body checking          | when a policy environment is assembled for one date   | supported calculations and every examined return case                                                             |
+| policy-history validation     | in the policy package's automated tests               | one representative date from every interval in which functions, parameters, or statutory currency may differ      |
+| tagged-input boundary         | when user input is prepared                           | known unit names, exact period suffixes, physical measure and scale, group marker, and source-currency conversion |
+| numerical currency conversion | immediately before and after policy calculation       | input into statutory currency and calculated output into data currency                                            |
 
-TTSIM uses Pint quantities while it checks declarations and policy environments,
-processes tagged input, and obtains currency conversion factors. The compiled tax and
-transfer calculation and JAX traces continue to use ordinary numerical arrays.
+TTSIM uses Pint only while it checks declarations and policy environments, processes
+unit-annotated input, and obtains currency conversion factors. The actual
+tax-and-transfer calculation continues to use ordinary numerical arrays, so units do not
+change the numerical representation used in a simulation.
 
 (gep-10-body-checker)=
 
@@ -1137,7 +1133,7 @@ with the function's declaration.
 
 TTSIM knows unit rules for a defined set of operations. For each supported operation,
 its checking version MUST inspect every argument that can affect the resulting unit.
-Scalar and vectorized versions of the same calculation MUST follow equivalent rules.
+Scalar and array-valued versions of the same calculation MUST follow equivalent rules.
 
 The checker rejects, among other things:
 
@@ -1158,8 +1154,8 @@ physical dimension, period, or group interpretation. In particular, it may not i
 array dimension, condition, merge key, fallback, or another argument relevant to units.
 
 The number of branches that TTSIM can examine is limited. If a function exceeds the
-documented limit on paths or decisions, environment assembly fails. The author must
-simplify the function or use a reported opt-out.
+documented limit on cases or branching decisions, TTSIM cannot complete the check. The
+author must simplify the function or use a reported opt-out.
 
 (gep-10-date-partition)=
 
@@ -1167,27 +1163,28 @@ simplify the function or use a reported opt-out.
 
 #### Checking all relevant policy dates
 
-Checking only the start dates of policy functions is not enough. A parameter, rounding
-rule, or statutory currency may change while the active functions remain the same. TTSIM
-therefore divides the supported date range into intervals within which the unit
-environment is constant.
+Checking only the start dates of policy functions is not enough. A parameter or the
+statutory currency may change while the active functions remain the same. Full-history
+validation therefore divides the supported date range into intervals within which the
+unit environment is constant.
 
 A new interval MUST begin at:
 
 - every function start date;
 - the day after every inclusive function end date;
 - every dated parameter entry, including a change only to its value, unit, set of
-  leaves, or currency;
-- every change of statutory currency; and
-- every separate rounding-rule date not already represented by a function boundary.
+  leaves, or currency; and
+- every change of statutory currency.
 
-TTSIM limits these boundaries to the dates supported by the policy package. It assembles
-and checks at least one representative date—normally the first date—in every resulting
-interval.
+Rounding specifications belong to dated function versions in the present design, so a
+rounding change is already captured by a function boundary. If a future design allows a
+rounding rule to change independently, its date MUST also start a new interval.
 
-`ttsim.testing_utils.get_policy_date_partition` provides this date partition for TTSIM
-policy packages. A parameter-only or currency-only change must start a new interval even
-when no policy function changes.
+`ttsim.testing_utils.get_policy_date_partition` limits these boundaries to the dates
+supported by the policy package and returns one representative date—normally the first
+date—per interval. The policy package's automated tests MUST assemble and check the
+environment at every returned date. A parameter-only or currency-only change must start
+a new interval even when no policy function changes.
 
 (gep-10-evidence)=
 
@@ -1195,29 +1192,31 @@ when no policy function changes.
 
 #### Validation report
 
-Every environment check MUST separate the coverage of declarations from the coverage of
-function bodies. Field names may differ across implementations, but the report contains
-at least:
+The validation report for a policy package MUST separate the coverage of declarations
+from the coverage of function bodies. Field names may differ across implementations, but
+the report contains at least:
 
 ```text
 resolved declarations
 checked function bodies
-generated nodes checked by rule
+automatically generated calculations checked by rule
 local casts used
 function bodies opted out with verify_units=False
 bodies rejected as unsupported
+other function bodies not checked, with reasons
 policy-date regimes checked
 ```
 
-A count is not enough for an exception. The report also names every function or node
-that uses `cast_ttsim_unit` or `verify_units=False`.
+A count is not enough for an exception. The report also names every function or
+calculation that uses `cast_ttsim_unit` or `verify_units=False`, and every other
+function whose body was not checked.
 
 A project may correctly report that every required declaration is present even when some
 bodies are unchecked. It may report that every supported, non-exempt body passed the
 unit checker. It MUST NOT call an opted-out body verified, and “100% annotated” MUST NOT
 be used as another name for “100% of bodies checked.”
 
-For example, CI might report:
+For example, an automated test run might report:
 
 ```text
 Declarations resolved: 412 / 412
@@ -1226,6 +1225,7 @@ Generated rules:         28
 Casts:                     9
 Body opt-outs:             4
 Unsupported bodies:        0
+Other unchecked bodies:     2
 Date regimes:             37
 ```
 
@@ -1233,11 +1233,12 @@ Date regimes:             37
 
 #### Error messages
 
-A unit error SHOULD identify the policy node, date or date interval, source expression,
-expected unit, inferred unit, and failing operation. An error in a conditional or
-`xnp.where` SHOULD identify the condition or the two incompatible results. A join error
-SHOULD say whether a key or fallback caused it. An unsupported reduction SHOULD name the
-operation and explain that the checker lacks information about its rows or axes.
+A unit error SHOULD identify the policy calculation, date or date interval, source
+expression, expected unit, inferred unit, and failing operation. An error in a
+conditional or `xnp.where` SHOULD identify the condition or the two incompatible
+results. A join error SHOULD say whether a key or fallback caused it. An unsupported
+reduction SHOULD name the operation and explain that the checker lacks information about
+the observations or array dimensions being combined.
 
 An error message should not present a cast as the standard repair. It may mention a
 local cast or body opt-out, but it must explain that the former is an assertion and the
@@ -1248,35 +1249,40 @@ latter removes body coverage.
 #### Trade-offs and limitations
 
 **Different dimensionless meanings are usually not checked.** Shares, identifiers,
-categories, rates without a period, and ordinary scalars all use `DIMENSIONLESS`. TTSIM
-cannot generally reject calculations between them. The condition rule excludes values
-with physical units or periods, but it does not by itself prove that a dimensionless
-value is a Boolean.
+category codes, counts, yes/no values, rates without a period, and ordinary scalars all
+use `DIMENSIONLESS`. TTSIM generally cannot reject calculations that confuse these
+meanings. For conditions, it only screens out values with physical units or periods;
+passing that screen does not establish the meaning of the remaining dimensionless value.
 
 **Equality does not compare units.** This permits useful sentinel comparisons such as
 `p_id_empfänger == -1`. It also means that the checker does not catch an equality
 comparison between monthly and annual income.
 
-**Group markers do not validate the data layout.** They do not prove that rows are
-aligned, keys are unique, a merge has the right number of matches, or an identifier
-belongs to a particular domain. A household-specific share remains bare because this GEP
-records its unit, not where it is stored in the dataset.
+**Group markers do not fully describe grain or validate the data layout.** They do not
+prove that rows are aligned, keys are unique, a merge has the right number of matches,
+or an identifier belongs to a particular domain. For example, a household's housing-cost
+share uses `DIMENSIONLESS`, not `DIMENSIONLESS_PER_HH`: the share has no physical
+household denominator, even though it varies across households. The group marker records
+selected group totals, counts, and indicators, not simply the level at which a variable
+is observed.
 
 **Only selected group calculations are supported.** TTSIM checks the head-count
 conversions, scalar changes, logical rules, and generated aggregations stated above.
 Other products or ratios involving group-marked values need a local assertion or an
 opt-out.
 
-**Branch checking has a limit.** A body that exceeds the path or decision limit is not
-silently accepted.
+**Branch checking has a limit.** A body that exceeds the limit on cases or branching
+decisions is not silently accepted.
 
 **Some operations remain unsupported.** Raw array reductions are rejected. Joins receive
 only the unit checks described above; they do not show that the keys identify the same
 kind of entity or that the merge produces the intended number of matches.
 
-**Tagged-input validation is partial.** It checks valid unit names, exact period
-suffixes, and currency conversion. It does not compare every physical or group component
-of the tag with the declaration of the target node.
+**Unit-annotated input checks units, not economic meaning or data arrangement.** The
+boundary compares monetary status, period, physical measure and scale, and group marker
+with the policy declaration, and it converts an allowed source currency. It still cannot
+tell whether a dimensionless code is the intended identifier, share, category, or count,
+or whether observations are aligned with the correct people and groups.
 
 **Automatic period ratios are conventions.** A valid conversion of units does not prove
 that the ratio follows a policy's legal day-count, partial-period, or compounding rule.
@@ -1315,6 +1321,8 @@ validation report.
 aggregation. The declared output unit still tells downstream functions what the result
 represents. An opt-out is appropriate only when the body:
 
+- constructs a schedule or another structured object whose input and output units are
+  checked separately;
 - uses an unsupported operation;
 - exceeds the branch-checking limit; or
 - implements a policy interpretation that the documented unit rules cannot express.
@@ -1337,11 +1345,17 @@ An implementation conforms to this GEP only if all of the following hold:
 1. supported joins inspect both keys and fallbacks, and do not imply that unchecked
    merge properties were validated;
 1. a raw reduction fails when TTSIM cannot determine the level of its result;
-1. the checked date intervals include all relevant function, parameter, rounding, and
-   statutory-currency boundaries;
+1. unit-annotated input is checked against the policy declaration for monetary status,
+   period, physical measure and scale, and group marker, with source-currency conversion
+   handled explicitly;
+1. quarter-of-year, month-of-year, and day-of-month values follow the ordinal rules in
+   this GEP rather than general calendar-point arithmetic;
+1. the checked date intervals include every relevant function boundary, including a
+   rounding change attached to a new function version, parameter entry, and
+   statutory-currency change;
 1. every policy regime uses exactly one statutory currency; and
-1. validation output reports declarations, checked bodies, generated rules, casts, and
-   whole-body opt-outs separately.
+1. validation output reports declarations, checked bodies, generated rules, casts,
+   whole-body opt-outs, and every other unchecked body separately.
 
 Passing the ordinary project tests is not enough to demonstrate these requirements. The
 implementation tests SHOULD deliberately introduce a mistake for every rule. Examples
@@ -1354,12 +1368,13 @@ date on which only a parameter or currency changes.
 
 - {ref}`GEP 1 <gep-1>` defines the period and group suffixes checked here.
 - {ref}`GEP 2 <gep-2>` defines `*_id` columns and group creation.
-- {ref}`GEP 4 <gep-4>` defines the DAG, aggregations, and generated period conversions.
+- {ref}`GEP 4 <gep-4>` defines the calculation graph, aggregations, and generated period
+  conversions.
 - {ref}`GEP 5 <gep-5>` defines rounding specifications.
-- {ref}`GEP 9 <gep-9>` defines runtime type checking and the conversion from user data
-  to the standard internal data format.
-- [Pint](https://pint.readthedocs.io) supplies the physical-unit registry and ordinary
-  unit arithmetic.
+- {ref}`GEP 9 <gep-9>` defines checks of values supplied when the model runs and their
+  conversion to the standard internal data format.
+- [Pint](https://pint.readthedocs.io) supplies the physical-unit definitions and
+  ordinary unit arithmetic.
 - [GETTSIM #1205](https://github.com/ttsim-dev/gettsim/issues/1205) tracks legally
   sensitive reference-period conventions.
 - [GETTSIM #1219](https://github.com/ttsim-dev/gettsim/issues/1219) records the review
@@ -1370,14 +1385,14 @@ date on which only a parameter or currency changes.
 The implementation is split between TTSIM infrastructure and the unit declarations in
 each policy system.
 
-- TTSIM [#138](https://github.com/ttsim-dev/ttsim/pull/138) contains the unit registry,
-  vocabulary, declarations, generated aggregation rules, body checker, and input
-  boundary.
+- TTSIM [#138](https://github.com/ttsim-dev/ttsim/pull/138) contains the unit
+  definitions, vocabulary, declarations, generated aggregation rules, body checker, and
+  input boundary.
 - TTSIM [#141](https://github.com/ttsim-dev/ttsim/pull/141) adds units to the fictional
   METTSIM policy system.
 - TTSIM [#150](https://github.com/ttsim-dev/ttsim/pull/150) strengthens the checks for
-  conditions, `xnp.where`, joins, reductions, stocks and flows, and policy-date
-  intervals.
+  conditions, `xnp.where`, joins, and reductions; corrects the METTSIM stock/flow
+  declaration; and expands the policy-date intervals that are checked.
 - GETTSIM [#1193](https://github.com/ttsim-dev/gettsim/pull/1193) contains GEP 10.
 - GETTSIM [#1212](https://github.com/ttsim-dev/gettsim/pull/1212) adds the declarations
   to GETTSIM.
@@ -1389,20 +1404,22 @@ requirements added by this revision:
   indicators;
 - restrict general products and ratios between group-marked quantities;
 - keep `MEAN` at the target group level rather than treating it as person-level;
-- report casts and whole-body opt-outs separately from checked bodies; and
-- use the calendar-year and ordinal meanings stated here in the public documentation.
+- report casts, whole-body opt-outs, and every other body that could not be checked
+  separately from checked bodies; and
+- implement the calendar-year and ordinal meanings stated here consistently in the
+  declarations, checks, and public documentation.
 
 (gep-10-alternatives)=
 
 ## Alternatives
 
-### A broader system for units, data levels, and economic meaning
+### A broader system for units, data grain, and economic meaning
 
 Deferred. A broader design could separately record the physical unit, economic meaning,
-observation level, kind of identifier, whether a value is a total or intensive measure,
-array dimensions, calendar meaning, currency history, and missing-value rules. It could
-then check more merge operations, row alignment, group-specific shares, and coefficients
-with inverse units.
+grain, kind of identifier, whether a value is a total or intensive measure, array
+dimensions, calendar meaning, currency history, and missing-value rules. It could then
+check more merge operations, row alignment, group-specific shares, and coefficients with
+inverse units.
 
 Such a system would be much larger than the unit checks needed for the current GETTSIM
 and METTSIM rollout. This GEP therefore focuses on physical units, periods, and selected
@@ -1417,11 +1434,12 @@ useful distinction between them would therefore require additional rules beyond 
 This GEP keeps the public unit vocabulary small, documents what remains unchecked, and
 adds only the condition and group-declaration rules needed for its stated guarantees.
 
-### A complete model of the dataset's observation level
+### A complete model of data grain
 
-Deferred. The group markers in this GEP support selected arithmetic; they are not types
-for rows or merge keys. The kind and uniqueness of identifiers, the number of merge
-matches, broadcasting, and row alignment remain outside scope. A reduction that would
+Deferred. The group markers in this GEP support selected arithmetic; they are not a
+complete model of data grain and are not types for rows or merge keys. The kind and
+uniqueness of identifiers, the number of merge matches, automatic repetition across rows
+or array dimensions, and row alignment remain outside scope. A reduction that would
 require such information is rejected instead of being assigned an unchanged unit.
 
 ### An explicit person-level unit
@@ -1444,12 +1462,12 @@ formula. The adopted design calculates each regime entirely in its statutory cur
 keeps parameter and coefficient values as written, and converts only input and
 calculated output at the boundary.
 
-### Pass Pint quantities through the calculation DAG
+### Pass Pint quantities through the calculation graph
 
 Rejected. `pint.Quantity` is not part of the intended NumPy/JAX numerical data. Units
 are checked while a policy environment is assembled and at its input and output
-boundaries. The compiled tax and transfer function continues to receive ordinary numbers
-and arrays.
+boundaries. The actual tax-and-transfer calculation continues to receive ordinary
+numbers and arrays.
 
 ### Remove concrete currencies from parameter declarations
 

--- a/docs/geps/gep-10.md
+++ b/docs/geps/gep-10.md
@@ -50,15 +50,6 @@ input into that statutory currency before the calculation and converts results i
 user's requested currency only after the statutory calculation and rounding are
 complete.
 
-## Normative language
-
-The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**,
-**SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **NOT RECOMMENDED**, **MAY**, and
-**OPTIONAL** in this document are to be interpreted as described in
-[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and
-[RFC 8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in
-capital letters.
-
 ## Motivation and scope
 
 This GEP addresses four recurring sources of mistakes.
@@ -88,9 +79,9 @@ library for calculations with units, and covers:
 - unit declarations for policy functions, inputs, parameters, schedules, structured
   values, automatically generated calculations, aggregations, rounding rules, and
   optionally unit-annotated input data;
-- narrow count/indicator evidence attached to the exact scalar, mapping leaf, raw or
-  converted schedule axis, schedule output, or structured-field occurrence that it
-  authorizes;
+- explicit `COUNT` and `INDICATOR` declarations, and automatically recognized Boolean or
+  generated results, attached to the exact scalar, mapping leaf, schedule axis, schedule
+  output, or structured-field occurrence they describe;
 - checking the supported expressions inside policy functions;
 - explicit rules for conditions, `xnp.where` (an array-valued if-then-else), joins
   (merges), and reductions such as sums over arrays;
@@ -134,8 +125,8 @@ This conclusion depends on three conditions:
 1. the checker reaches all relevant cases within its documented limits; and
 1. TTSIM's checking version of each operation represents the real operation faithfully.
 
-A successful check MUST NOT be summarized as “all functions are unit-correct.”
-Documentation and continuous-integration output MUST report at least:
+A successful check must not be summarized as “all functions are unit-correct.” The
+validation report used in continuous integration must distinguish at least:
 
 - declarations that were found and resolved;
 - policy-function bodies that were checked;
@@ -218,7 +209,7 @@ results = main(
 )
 ```
 
-The data-boundary checks MUST be described exactly. They verify that:
+The data-boundary checks must be described exactly. They verify that:
 
 - an unknown unit name is an error;
 - the period in the unit agrees exactly with the GEP-1 suffix of the column name;
@@ -345,7 +336,7 @@ einkommensgrenze_m:
     value: 1000.0
 ```
 
-A monetary parameter MUST name a concrete currency. For every date on which the
+A monetary parameter must name a concrete currency. For every date on which the
 parameter entry is used, that currency must be the statutory currency of the policy
 regime.
 
@@ -361,17 +352,16 @@ regime.
 - `DIMENSIONLESS` continues to cover shares, rates without a period, identifiers,
   categories, and other physically dimensionless numbers. This GEP does not add a
   separate public unit category for every economic meaning.
-- `QuantityKind` is narrow supporting information, not another unit. It is used only to
-  distinguish a known count or yes/no indicator from another dimensionless value where a
-  group marker is declared. For a multi-axis schedule, any non-generic kind is stated
-  separately for each axis.
+- `COUNT` and `INDICATOR` explicitly mark hand-written counts and yes/no indicators.
+  They behave as dimensionless values in Pint calculations. Their extra meaning is used
+  only for the restricted group calculations in this GEP.
 - `verify_units=False` may exclude one function body from checking, but the report lists
-  it as unchecked. It MUST NOT count as a checked body.
+  it as unchecked. It must not count as a checked body.
 - `cast_ttsim_unit` remains available for a local unit assertion. The report lists each
   use separately from units inferred by TTSIM.
 - Unit checks are included by default when a policy environment is assembled. When
   explicit output targets are supplied, `include_fail_nodes=False` can omit unit-related
-  failure checks from that call. Results from such a call MUST NOT be described as
+  failure checks from that call. Results from such a call must not be described as
   unit-validated, even though some invalid declarations may still be rejected earlier.
 
 ## Detailed description
@@ -388,7 +378,7 @@ regime.
 1. **Describe the check accurately.** TTSIM checks a defined set of expressions. It does
    not prove arbitrary Python code correct.
 1. **Check every relevant argument.** If a condition, fallback value, key, period, or
-   other argument can affect the unit of a supported operation, the checker MUST inspect
+   other argument can affect the unit of a supported operation, the checker must inspect
    it.
 1. **Reject unsupported changes of level.** If an operation may change the level at
    which a result is defined and TTSIM lacks the necessary array or grouping
@@ -405,28 +395,28 @@ regime.
 
 ### Terminology
 
-| Term               | Meaning                                                                                                                                                                                                                          |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| quantity           | A value with a unit, such as income, age, a share, or a head count.                                                                                                                                                              |
-| base               | What is measured in the numerator, such as `CURRENCY`, `DIMENSIONLESS`, or `YEARS`.                                                                                                                                              |
-| period             | A denominator such as `MONTH` or `YEAR` that identifies a flow or rate.                                                                                                                                                          |
-| level              | The person or group for which a variable is defined or varies, such as person, household, or Bedarfsgemeinschaft.                                                                                                                |
-| group              | A level other than person, such as `HH` or `BG`, which may appear as a denominator.                                                                                                                                              |
-| group marker       | A denominator such as `HH` or `BG` that checks selected amounts, counts, or indicators at that level. It is not a complete representation of the level.                                                                          |
-| quantity kind      | Narrow supporting information—`GENERIC`, `COUNT`, or `INDICATOR`—used only when deciding whether a dimensionless value may carry a group marker. It belongs to one exact declared value or schedule axis and is not a Pint unit. |
-| stock              | A quantity without a period denominator, such as wealth.                                                                                                                                                                         |
-| flow               | A quantity with a period denominator, such as monthly income.                                                                                                                                                                    |
-| rate               | A multiplier. A rate that converts a stock to a flow has a period denominator.                                                                                                                                                   |
-| calendar point     | A location on a calendar, such as the year 2025.                                                                                                                                                                                 |
-| calendar ordinal   | A position within a larger calendar unit, such as month 2 or day 15.                                                                                                                                                             |
-| calendar duration  | A length of time, such as 18 years or 3 months.                                                                                                                                                                                  |
-| statutory currency | The currency in which the law states the active parameters and rounding rules.                                                                                                                                                   |
-| data currency      | The currency assumed for untagged input and requested for calculated output.                                                                                                                                                     |
-| policy environment | The functions, inputs, parameters, and automatically generated calculations that apply on one policy date.                                                                                                                       |
-| leaf               | A final value in a nested input or parameter structure, rather than a dictionary containing further entries.                                                                                                                     |
-| body check         | Running supported policy formulas with unit-carrying test values and comparing the result with the declared unit.                                                                                                                |
-| cast               | A local assertion that tells the checker to use a stated unit for one expression.                                                                                                                                                |
-| opt-out            | `verify_units=False` on one function. Its output declaration still applies, but its calculations are not checked.                                                                                                                |
+| Term                           | Meaning                                                                                                                                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| quantity                       | A value with a unit, such as income, age, a share, or a head count.                                                                                                                         |
+| base                           | What is measured in the numerator, such as `CURRENCY`, `DIMENSIONLESS`, or `YEARS`.                                                                                                         |
+| period                         | A denominator such as `MONTH` or `YEAR` that identifies a flow or rate.                                                                                                                     |
+| level                          | The person or group for which a variable is defined or varies, such as person, household, or Bedarfsgemeinschaft.                                                                           |
+| group                          | A level other than person, such as `HH` or `BG`, which may appear as a denominator.                                                                                                         |
+| group marker                   | A denominator such as `HH` or `BG` that checks selected amounts, counts, or indicators at that level. It is not a complete representation of the level.                                     |
+| count or indicator declaration | `COUNT` or `INDICATOR` on one exact declared value or schedule axis. Both are dimensionless in Pint; the explicit spelling supplies only the narrow information needed for the group rules. |
+| stock                          | A quantity without a period denominator, such as wealth.                                                                                                                                    |
+| flow                           | A quantity with a period denominator, such as monthly income.                                                                                                                               |
+| rate                           | A multiplier. A rate that converts a stock to a flow has a period denominator.                                                                                                              |
+| calendar point                 | A location on a calendar, such as the year 2025.                                                                                                                                            |
+| calendar ordinal               | A position within a larger calendar unit, such as month 2 or day 15.                                                                                                                        |
+| calendar duration              | A length of time, such as 18 years or 3 months.                                                                                                                                             |
+| statutory currency             | The currency in which the law states the active parameters and rounding rules.                                                                                                              |
+| data currency                  | The currency assumed for untagged input and requested for calculated output.                                                                                                                |
+| policy environment             | The functions, inputs, parameters, and automatically generated calculations that apply on one policy date.                                                                                  |
+| leaf                           | A final value in a nested input or parameter structure, rather than a dictionary containing further entries.                                                                                |
+| body check                     | Running supported policy formulas with unit-carrying test values and comparing the result with the declared unit.                                                                           |
+| cast                           | A local assertion that tells the checker to use a stated unit for one expression.                                                                                                           |
+| opt-out                        | `verify_units=False` on one function. Its output declaration still applies, but its calculations are not checked.                                                                           |
 
 (gep-10-valuespec)=
 
@@ -441,6 +431,7 @@ denominator, one period denominator, and one group denominator, in that order.
 base        := CURRENCY
              | EUR | DM
              | DIMENSIONLESS
+             | COUNT | INDICATOR
              | HOURS
              | SQUARE_METER | HECTARE
              | YEARS | QUARTERS | MONTHS | DAYS
@@ -464,6 +455,8 @@ unit        := base
 The fixed order gives each unit exactly one spelling. For example,
 `EUR_PER_MONTH_PER_YEAR` is invalid because it contains two period denominators.
 `EUR_PER_BG_PER_MONTH` is also invalid; the correct order is `EUR_PER_MONTH_PER_BG`.
+`COUNT` and `INDICATOR` may be used alone or with one group denominator; they cannot
+have a physical or period denominator.
 
 In Python, units are built by chaining attributes:
 
@@ -472,6 +465,8 @@ TTSIMUnit.CURRENCY.PER_MONTH.PER_BG
 TTSIMUnit.CURRENCY
 TTSIMUnit.DIMENSIONLESS
 TTSIMUnit.DIMENSIONLESS.PER_YEAR
+TTSIMUnit.COUNT.PER_HH
+TTSIMUnit.INDICATOR.PER_HH
 TTSIMUnit.HOURS.PER_WEEK
 ```
 
@@ -479,20 +474,21 @@ YAML uses the same components joined by `_PER_`.
 
 #### Common declarations
 
-| Declaration                           | Meaning                                      | Example                                                        |
-| ------------------------------------- | -------------------------------------------- | -------------------------------------------------------------- |
-| `CURRENCY_PER_MONTH`                  | currency per month                           | personal monthly income                                        |
-| `CURRENCY_PER_MONTH_PER_BG`           | currency per month for a Bedarfsgemeinschaft | monthly amount assigned to a Bedarfsgemeinschaft               |
-| `CURRENCY`                            | a currency stock                             | wealth                                                         |
-| `DIMENSIONLESS`                       | no physical unit                             | share, identifier, category, or rate without a period          |
-| `DIMENSIONLESS_PER_YEAR`              | one per year                                 | linear annual rate applied to a stock                          |
-| `DIMENSIONLESS_PER_BG`                | count or indicator for a Bedarfsgemeinschaft | number of people in the group or a group eligibility indicator |
-| `HOURS_PER_WEEK`                      | working hours per week                       | weekly working hours                                           |
-| `CURRENCY_PER_HOURS`                  | currency per working hour                    | hourly wage                                                    |
-| `CURRENCY_PER_SQUARE_METER_PER_MONTH` | currency per square meter per month          | monthly rent ceiling per square meter                          |
-| `YEARS`                               | a duration measured in years                 | age                                                            |
-| `CALENDAR_YEAR`                       | a particular calendar year                   | birth year                                                     |
-| `CALENDAR_MONTH`                      | a month-of-year number                       | February represented as `2`                                    |
+| Declaration                           | Meaning                                      | Example                                               |
+| ------------------------------------- | -------------------------------------------- | ----------------------------------------------------- |
+| `CURRENCY_PER_MONTH`                  | currency per month                           | personal monthly income                               |
+| `CURRENCY_PER_MONTH_PER_BG`           | currency per month for a Bedarfsgemeinschaft | monthly amount assigned to a Bedarfsgemeinschaft      |
+| `CURRENCY`                            | a currency stock                             | wealth                                                |
+| `DIMENSIONLESS`                       | no physical unit                             | share, identifier, category, or rate without a period |
+| `DIMENSIONLESS_PER_YEAR`              | one per year                                 | linear annual rate applied to a stock                 |
+| `COUNT_PER_BG`                        | count for a Bedarfsgemeinschaft              | number of people in the group                         |
+| `INDICATOR_PER_BG`                    | yes/no indicator for a Bedarfsgemeinschaft   | group eligibility indicator                           |
+| `HOURS_PER_WEEK`                      | working hours per week                       | weekly working hours                                  |
+| `CURRENCY_PER_HOURS`                  | currency per working hour                    | hourly wage                                           |
+| `CURRENCY_PER_SQUARE_METER_PER_MONTH` | currency per square meter per month          | monthly rent ceiling per square meter                 |
+| `YEARS`                               | a duration measured in years                 | age                                                   |
+| `CALENDAR_YEAR`                       | a particular calendar year                   | birth year                                            |
+| `CALENDAR_MONTH`                      | a month-of-year number                       | February represented as `2`                           |
 
 `CURRENCY` is used in Python when the concrete currency depends on the policy date.
 TTSIM resolves it to the statutory currency. Parameters, rounding rules, and tagged
@@ -503,24 +499,25 @@ input use a concrete currency whenever their denomination is already known.
 #### Dimensionless values with different economic meanings
 
 Several economically different values have no physical unit. Examples are a marginal tax
-rate, a probability, a person identifier, a category code, and a number of people. All
-use `DIMENSIONLESS` unless this GEP gives a more specific rule, such as a period on a
-rate or a group marker on a known count or indicator.
+rate, a probability, a person identifier, a category code, and a number of people.
+Shares, identifiers, categories, and rates without a period use `DIMENSIONLESS`. A
+hand-written count or numeric yes/no indicator uses `COUNT` or `INDICATOR`. These two
+spellings still resolve to the dimensionless Pint unit; they only tell TTSIM which of
+the restricted group calculations below is valid.
 
-For the restricted group-marker rules, TTSIM may record one narrow `QuantityKind`:
-`GENERIC`, `COUNT`, or `INDICATOR`. This information is not another public unit and does
-not distinguish economic meanings. It answers only whether one particular dimensionless
-declaration is independently known to be a count or yes/no indicator. Like any
-declaration supplied by an author, explicit `QuantityKind` metadata can be wrong; it
-does not prove the economic meaning of the underlying data.
+A Boolean return type or Boolean parameter value already establishes a yes/no indicator.
+Generated `COUNT`, Boolean `SUM`, `ANY`, and `ALL` calculations likewise establish their
+meaning automatically. Names, qualified names, and documentation never establish that a
+number is a count or indicator. For example, an integer called `anzahl_kinder` remains a
+generic dimensionless value unless its declaration says `COUNT`.
 
 The evidence is local. A scalar function or input, one leaf of a mapping, each input
 axis of a raw parameter table or converted schedule, the schedule output, and each
 occurrence of a field in a nested structured value are separate declarations. Evidence
-for one of them MUST NOT authorize another. In particular, a count description on a
-parent object or sibling leaf does not authorize a category leaf; a count axis does not
-authorize another schedule axis; and evidence at one occurrence of a reused nested type
-does not authorize a different occurrence.
+for one of them must not authorize another. In particular, a `COUNT` declaration on a
+sibling leaf does not authorize a category leaf; a count axis does not authorize another
+schedule axis; and a declaration at one occurrence of a reused nested type does not
+authorize a different occurrence.
 
 A successful unit check therefore does not show that an identifier was never multiplied
 by a share or that two identifiers refer to the same kind of entity. Such checks would
@@ -573,23 +570,20 @@ happens to be stored after a Stata `merge` or `bysort`: repeating a household sh
 all household members does not turn the share into a household total. GEP 10 does not
 check whether such repeated values are aligned with the correct rows.
 
-Declaration validation MUST enforce the following restriction. A direct
-`DIMENSIONLESS.PER_<GROUP>` declaration is allowed only for a count or yes/no indicator
-whose meaning is established independently of its unit **for that exact declaration**.
-Generated `COUNT`, the sum of a yes/no indicator, `ANY`, and `ALL` qualify
-automatically. A Boolean return type establishes an indicator. A directly declared
-integer value may qualify as a count when its own name, documentation, or explicit
-`QuantityKind.COUNT` metadata states that interpretation unambiguously, although an
-integer return type alone does not distinguish a count from an identifier or category
-code.
+Declaration validation enforces the following restriction. A direct group-marked count
+uses `COUNT.PER_<GROUP>` in Python or `COUNT_PER_<GROUP>` in YAML. A direct group-marked
+numeric yes/no indicator uses the corresponding `INDICATOR` spelling. A Boolean return
+type or Boolean parameter value may use `DIMENSIONLESS.PER_<GROUP>` because its type or
+value supplies the same local evidence. An integer type alone does not distinguish a
+count from an identifier or category code.
 
-Evidence MUST NOT be borrowed from an enclosing object, sibling mapping leaf, another
-schedule axis, the schedule output, or another occurrence of the same nested structured
-type. General descriptions such as “number of children and rent class” do not establish
-that both components are counts. A floating-point share, probability, identifier,
-category, or rate without a period carrying a group marker is rejected. If TTSIM cannot
-establish one of the permitted cases for the exact declaration carrying the marker, it
-MUST reject the declaration rather than guess.
+The declaration must be attached to the exact scalar, mapping leaf, schedule axis,
+schedule output, or structured-field occurrence that it describes. It must not be
+borrowed from an enclosing object, sibling mapping leaf, another schedule axis, the
+schedule output, or another occurrence of the same nested structured type. A share,
+probability, identifier, category, or rate without a period cannot carry a group marker.
+If TTSIM cannot establish one of the permitted cases for the exact declaration carrying
+the marker, it must reject the declaration rather than guess.
 
 #### Restricted group calculations
 
@@ -614,9 +608,8 @@ TTSIM checks the following group calculations:
 1. Multiplication or division between quantities carrying different group markers is
    rejected.
 
-TTSIM MAY record internally that a value comes from `COUNT`, Boolean `SUM`, or another
-explicit head-count calculation. This internal information does not create another
-public unit.
+TTSIM may retain the count or indicator meaning internally while checking a formula.
+This internal information does not create another physical unit.
 
 For example, dividing a household rent total by the household head count produces a
 person-level amount:
@@ -657,7 +650,7 @@ When a comparison or logical operation produces a yes/no result, TTSIM may use t
 when checking later operations. This information comes from the operation that produced
 the result, not from its `DIMENSIONLESS` unit.
 
-The same dimensionless requirement MUST apply to:
+The same dimensionless requirement must apply to:
 
 - Python `if` statements and conditional expressions;
 - `bool(value)` calls made while branches are checked;
@@ -673,7 +666,7 @@ def invalid(wealth: float) -> float:
     return wealth if wealth else 0.0
 ```
 
-`xnp.where` MUST check its condition as well as the two possible results. Rewriting a
+`xnp.where` must check its condition as well as the two possible results. Rewriting a
 scalar conditional as an array-valued `xnp.where` must not remove this check.
 
 When two yes/no results carry the same group marker, the result keeps that marker. If
@@ -729,13 +722,11 @@ December + 2 months
 February 29 without a year and calendar
 ```
 
-The current implementation still represents framework values such as `policy_quarter`,
-`policy_month`, and `policy_day` as dimensionless numbers. This is a temporary
-implementation limitation, not a different calendar model: a successful unit check does
-not certify their ranges or their complete calendar meaning, and it does not permit the
-arithmetic ruled out above. Before full conformance, TTSIM must apply the ordinal rules
-stated here consistently. A later calendar proposal may add ranges and calendar context
-without changing the physical unit system defined here.
+TTSIM assigns `CALENDAR_YEAR`, `CALENDAR_MONTH`, and `CALENDAR_DAY` to the corresponding
+policy-date and evaluation-date framework values. These declarations check the
+arithmetic above, but they do not certify that a value lies in a valid numerical range.
+A later calendar proposal may add range checks and calendar context without changing the
+physical unit system defined here.
 
 Converting an annual flow into a monthly flow is separate from calendar arithmetic.
 `CURRENCY_PER_YEAR` to `CURRENCY_PER_MONTH` uses a reference-period ratio; it does not
@@ -813,9 +804,8 @@ the output and must agree with `output_unit`.
 
 For a raw parameter table or converted schedule with several input axes, the units are
 ordered exactly like the arguments of the lookup call. Each axis is checked separately.
-If a dimensionless group-marked axis needs count or indicator evidence, that evidence
-belongs to the same position and to no other axis. The output has its own, separate
-evidence.
+A numeric group-marked count or yes/no axis declares `COUNT` or `INDICATOR` in its own
+position. The output has its own, separate declaration.
 
 #### Parameter functions
 
@@ -837,36 +827,31 @@ def tarif() -> PiecewisePolynomialParamValue: ...
 ```
 
 A lookup table may have several input axes. Suppose the first axis is a household head
-count and the second is a rent class. Only the first may carry the household group
-marker and count evidence:
+count and the second is a rent class. Only the first carries the household group marker
+and the explicit count declaration:
 
 ```python
-from gettsim.tt import InputOutputUnits, QuantityKind, TTSIMUnit
+from gettsim.tt import InputOutputUnits, TTSIMUnit
 
 
 @param_function(
     unit=InputOutputUnits(
         input_unit=(
-            TTSIMUnit.DIMENSIONLESS.PER_HH,
+            TTSIMUnit.COUNT.PER_HH,
             TTSIMUnit.DIMENSIONLESS,
         ),
         output_unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_HH,
-        input_kind=(
-            QuantityKind.COUNT,
-            QuantityKind.GENERIC,
-        ),
     ),
     verify_units=False,
 )
 def maximum_rent_m_hh() -> ConsecutiveIntLookupTableParamValue: ...
 ```
 
-If `input_unit` is a tuple, a non-generic `input_kind` MUST be a tuple of the same
-length and is interpreted position by position. A scalar `QuantityKind.COUNT` or
-`QuantityKind.INDICATOR` MUST NOT be repeated automatically across several input axes.
-The default `QuantityKind.GENERIC` MAY stand for all-generic axes. `output_kind` applies
-only to the output and MUST NOT authorize an input axis. An arity mismatch is a
-declaration error.
+If `input_unit` is a tuple, its entries are interpreted position by position. A `COUNT`
+or `INDICATOR` spelling applies only to that entry; it is never repeated automatically
+across the other axes. `output_unit` applies only to the output and cannot authorize an
+input axis. A mismatch between the number of declared axes and the schedule arguments is
+a declaration error.
 
 The explicit opt-out applies to the code that constructs the schedule object, which is
 not a numerical policy formula. It does not remove the schedule's unit contract: for
@@ -906,7 +891,7 @@ deliberately rename or transform values. That mapping therefore remains a matter
 focused tests and policy review.
 
 Every path through a structured value is validated separately. If the same nested
-dataclass type appears under two different fields, TTSIM MUST visit both occurrences and
+dataclass type appears under two different fields, TTSIM must visit both occurrences and
 must not stop after validating the type once. Evidence from an outer field name or
 description belongs only to that occurrence. Evidence written directly in the nested
 field's type annotation applies to every occurrence of that field because it is part of
@@ -972,7 +957,7 @@ The same applies to `MIN` and `MAX`: the minimum or maximum is a property of the
 group. The current unit system records the quantity, period, and group level. It does
 not otherwise distinguish a total, mean, minimum, and maximum once produced.
 
-A hand-written aggregation declares its result unit. The declaration MUST equal the unit
+A hand-written aggregation declares its result unit. The declaration must equal the unit
 derived from the source, aggregation type, and target level. If the standard rule does
 not express the intended interpretation, the aggregation must use `verify_units=False`.
 A later policy function may use a local cast for the smallest affected expression. The
@@ -989,8 +974,8 @@ identifiers belong to the same domain is outside this GEP.
 A supported `join` receives limited checks, analogous to those available for a Stata
 `merge`:
 
-- the foreign and primary keys MUST have no physical unit or period;
-- the fallback used for a missing key MUST have a unit compatible with the target,
+- the foreign and primary keys must have no physical unit or period;
+- the fallback used for a missing key must have a unit compatible with the target,
   except for the documented dimensionless sentinel case; and
 - the joined result has the unit of the target variable.
 
@@ -1010,7 +995,7 @@ of the result represents. Unlike a declared aggregation, a raw reduction does no
 the checker which observations or array dimensions were combined. This is similar to
 seeing a Stata total without knowing the `by()` variables.
 
-The checker therefore MUST reject these reductions inside a checked policy body instead
+The checker therefore must reject these reductions inside a checked policy body instead
 rather than copying the unit of its input. A function that needs such a reduction must:
 
 - express it as a generated or hand-written aggregation with a declared target level; or
@@ -1126,7 +1111,7 @@ UNIT_SYSTEM = UnitSystem(
 Exactly one currency is statutory on every supported policy date. All monetary
 calculations inside that policy regime use this currency.
 
-For every checked regime, environment assembly MUST verify that:
+For every checked regime, environment assembly must verify that:
 
 - each active monetary parameter uses the statutory currency;
 - each active monetary rounding rule uses the statutory currency;
@@ -1254,8 +1239,8 @@ expressions in turn. Each examined return value is compared with the function's
 declaration.
 
 TTSIM knows unit rules for a defined set of operations. For each supported operation,
-its checking version MUST inspect every argument that can affect the resulting unit.
-Scalar and array-valued versions of the same calculation MUST follow equivalent rules.
+its checking version must inspect every argument that can affect the resulting unit.
+Scalar and array-valued versions of the same calculation must follow equivalent rules.
 
 The checker rejects at least:
 
@@ -1274,7 +1259,7 @@ The checker rejects at least:
 - an operation for which TTSIM has no faithful unit rule, unless the function explicitly
   opts out.
 
-The checker MUST NOT assume that the old unit survives an operation that may change a
+The checker must not assume that the old unit survives an operation that may change a
 physical dimension, period, or group interpretation. In particular, it may not ignore an
 array dimension, condition, merge key, fallback, or another argument relevant to units.
 
@@ -1293,7 +1278,7 @@ statutory currency may change while the active functions remain the same. Full-h
 validation therefore divides the supported date range into intervals within which the
 unit environment is constant.
 
-A new interval MUST begin at:
+A new interval must begin at:
 
 - every function start date;
 - the day after every inclusive function end date;
@@ -1303,11 +1288,11 @@ A new interval MUST begin at:
 
 Rounding specifications belong to dated function versions in the present design, so a
 rounding change is already captured by a function boundary. If a future design allows a
-rounding rule to change independently, its date MUST also start a new interval.
+rounding rule to change independently, its date must also start a new interval.
 
 `ttsim.testing_utils.get_policy_date_partition` limits these boundaries to the dates
 supported by the policy package and returns one representative date per interval, by
-default the first. The policy package's automated tests MUST assemble and check the
+default the first. The policy package's automated tests must assemble and check the
 environment at every returned date. A parameter-only or currency-only change must start
 a new interval even when no policy function changes.
 
@@ -1315,7 +1300,7 @@ a new interval even when no policy function changes.
 
 #### Validation report
 
-The validation report for a policy package MUST separate the coverage of declarations
+The validation report for a policy package must separate the coverage of declarations
 from the coverage of function bodies. Field names may differ across implementations, but
 the report contains at least:
 
@@ -1334,9 +1319,15 @@ A count is not enough for an exception. The report also names every function or
 calculation that uses `cast_ttsim_unit` or `verify_units=False`, and every other
 function whose body was not checked.
 
+A policy package that accepts casts or body opt-outs keeps the exact reviewed names in
+continuous integration. The test fails if the set changes: an addition, removal, or
+replacement all require an explicit update to the reviewed baseline. Unsupported bodies
+are required to remain empty. This prevents exception growth while still making a
+deliberate cleanup visible in review.
+
 A project may correctly report that every required declaration is present even when some
 bodies are unchecked. It may report that every supported, non-exempt body passed the
-unit checker. It MUST NOT call an opted-out body verified, and “100% annotated” MUST NOT
+unit checker. It must not call an opted-out body verified, and “100% annotated” must not
 be used as another name for “100% of bodies checked.”
 
 For example, an automated test run might report:
@@ -1356,11 +1347,11 @@ Date regimes:             37
 
 #### Error messages
 
-A unit error SHOULD identify the policy calculation, date or date interval, source
+A unit error should identify the policy calculation, date or date interval, source
 expression, expected unit, inferred unit, and failing operation. An error in a
-conditional or `xnp.where` SHOULD identify the condition or the two incompatible
-results. A join error SHOULD say whether a key or fallback caused it. An unsupported
-reduction SHOULD name the operation and explain that the checker lacks information about
+conditional or `xnp.where` should identify the condition or the two incompatible
+results. A join error should say whether a key or fallback caused it. An unsupported
+reduction should name the operation and explain that the checker lacks information about
 the observations or array dimensions being combined.
 
 An error message should not present a cast as the standard repair. It may mention a
@@ -1373,12 +1364,13 @@ latter removes body coverage.
 
 **Different dimensionless meanings are checked only where a group marker is declared.**
 Shares, identifiers, category codes, counts, yes/no values, rates without a period, and
-other unitless scalars all use `DIMENSIONLESS`. Outside the group-marker cases above,
-TTSIM cannot reject calculations that confuse these meanings. `QuantityKind` provides
-only the narrow, local evidence needed for a dimensionless group marker; it is not a
-general semantic type and does not make other arithmetic between dimensionless values
-safe. For conditions, TTSIM only requires that the value be dimensionless; meeting that
-requirement does not establish the meaning of the remaining dimensionless value.
+other unitless scalars are all physically dimensionless. Outside the group-marker cases
+above, TTSIM cannot reject calculations that confuse these meanings. `COUNT` and
+`INDICATOR` provide only the narrow, local evidence needed for a dimensionless group
+marker; they are not general semantic types and do not make other arithmetic between
+dimensionless values safe. For conditions, TTSIM only requires that the value be
+dimensionless; meeting that requirement does not establish the meaning of the remaining
+dimensionless value.
 
 **Equality does not compare units.** This permits sentinel comparisons such as
 `p_id_empfänger == -1`. It also means that the checker does not catch an equality
@@ -1463,13 +1455,14 @@ successfully, but it must not claim that every body was checked.
 An implementation conforms to this GEP only if all of the following hold:
 
 1. every object that requires a unit has a valid declaration;
-1. a group marker on a dimensionless value is limited to a known count or indicator;
+1. a group marker on a dimensionless value is limited to a known count or indicator,
+   with direct numeric declarations using `COUNT` or `INDICATOR`;
 1. the count/indicator evidence belongs to the exact scalar, mapping leaf, raw or
    converted schedule input axis, schedule output, or structured-field occurrence
    carrying the group marker; it is not borrowed from a sibling, parent description,
    another axis, or another occurrence of a reused nested type;
-1. tuple-valued schedule inputs use positionally matched kind evidence of the same
-   arity, and a non-generic scalar kind is not broadcast across several axes;
+1. tuple-valued schedule inputs declare each axis positionally, and `COUNT` or
+   `INDICATOR` on one axis is not broadcast across the others;
 1. unsupported products, ratios, and calculations across group levels are rejected;
 1. `MEAN`, `MIN`, and `MAX` produce a result at the target group level;
 1. scalar conditions and `xnp.where` reject values with physical units or periods;
@@ -1489,7 +1482,7 @@ An implementation conforms to this GEP only if all of the following hold:
    whole-body opt-outs, and every other unchecked body separately.
 
 Passing the project's existing tests is not enough to demonstrate these requirements.
-The implementation tests SHOULD deliberately introduce a mistake for every rule.
+The implementation tests should deliberately introduce a mistake for every rule.
 Examples include returning a stock where a flow is declared, using money as a condition,
 passing an invalid condition to `xnp.where`, using a fallback with the wrong unit in a
 join, marking a share as a group total, letting a count axis authorize a rent-class
@@ -1510,40 +1503,14 @@ parameter or currency changes.
   dimensional arithmetic.
 - [GETTSIM #1205](https://github.com/ttsim-dev/gettsim/issues/1205) tracks legally
   sensitive reference-period conventions.
-- [GETTSIM #1219](https://github.com/ttsim-dev/gettsim/issues/1219) records the review
-  that led to the narrower guarantee and additional safeguards in this revision.
 
 ## Implementation
 
-The implementation is split between TTSIM infrastructure and the unit declarations in
-each policy system.
-
-- TTSIM [#138](https://github.com/ttsim-dev/ttsim/pull/138) contains the unit
-  definitions, vocabulary, declarations, generated aggregation rules, body checker, and
-  input boundary.
-- TTSIM [#141](https://github.com/ttsim-dev/ttsim/pull/141) adds units to the fictional
-  METTSIM policy system.
-- TTSIM [#150](https://github.com/ttsim-dev/ttsim/pull/150) strengthens the checks for
-  conditions, `xnp.where`, joins, and reductions; corrects the METTSIM stock/flow
-  declaration; and expands the policy-date intervals that are checked.
-- GETTSIM [#1193](https://github.com/ttsim-dev/gettsim/pull/1193) contains GEP 10.
-- GETTSIM [#1212](https://github.com/ttsim-dev/gettsim/pull/1212) adds the declarations
-  to GETTSIM.
-
-Before this GEP is described as implemented, the code and tests must also cover the
-requirements added by this revision:
-
-- reject group-level shares and rates while retaining the documented group counts and
-  indicators;
-- attach count/indicator evidence to the exact declaration it authorizes, including each
-  schedule axis and each occurrence of a nested structured field, without broadcasting a
-  non-generic kind or reusing evidence from siblings and repeated types;
-- restrict general products and ratios between group-marked quantities;
-- keep `MEAN` at the target group level rather than treating it as person-level;
-- report casts, whole-body opt-outs, and every other body that could not be checked
-  separately from checked bodies; and
-- implement the calendar-year and ordinal meanings stated here consistently in the
-  declarations, checks, and public documentation.
+TTSIM provides the unit vocabulary, declaration parser, generated aggregation rules,
+body checker, validation report, and input boundary. Each policy package supplies its
+unit system and declarations and runs full-history validation in continuous integration.
+GETTSIM supplies these declarations for the German policy system; METTSIM provides a
+small fictional policy system used for implementation tests and examples.
 
 (gep-10-alternatives)=
 
@@ -1580,13 +1547,12 @@ require such information is rejected instead of being assigned an unchanged unit
 
 ### An explicit person-level unit
 
-Rejected for this proposal. Earlier designs wrote every person amount as
-`... / [person]` and every group head count as `[person] / [group]`. This made the
-person level explicit but added a component to almost every declaration and allowed two
-ways to write the same person-level quantity.
+Rejected for this proposal. Writing every person amount as `... / [person]` and every
+group head count as `[person] / [group]` would add a component to almost every
+declaration and allow two ways to write the same person-level quantity.
 
-The adopted design leaves person quantities without a group denominator and writes a
-group head count as `1 / [group]`. After dividing a group total by its head count, TTSIM
+Person quantities therefore have no group denominator, and a group head count is
+represented as `1 / [group]`. After dividing a group total by its head count, TTSIM
 knows that the result no longer carries the group marker. It does not separately record
 that the result is stored at the person level.
 
@@ -1611,14 +1577,6 @@ Rejected. Because each regime uses one statutory currency, concrete labels may a
 redundant. They nevertheless document the denomination in the file and catch a mismatch
 with the regime. A Euro parameter used in a Deutsche-Mark regime should produce an
 immediate error.
-
-## Discussion
-
-- [GETTSIM #1193: GEP 10 — Units and Dimensionality](https://github.com/ttsim-dev/gettsim/pull/1193)
-- [GETTSIM #1219: review of GEP 10 and its prototype implementation](https://github.com/ttsim-dev/gettsim/issues/1219)
-- [TTSIM #138: units and dimensionality infrastructure](https://github.com/ttsim-dev/ttsim/pull/138)
-- [TTSIM #141: METTSIM annotations](https://github.com/ttsim-dev/ttsim/pull/141)
-- [TTSIM #150: targeted GEP-10 guards and date regimes](https://github.com/ttsim-dev/ttsim/pull/150)
 
 ## References and footnotes
 

--- a/docs/geps/gep-10.md
+++ b/docs/geps/gep-10.md
@@ -17,31 +17,37 @@
 
 ## Abstract
 
-This GEP introduces explicit units for nodes, parameters, inputs, generated operations,
-rounding specifications, and results in TTSIM and GETTSIM. A unit records what a value
-measures, whether it is a stock or a flow, its reference period, and, for a restricted
-class of measurable group quantities, the group to which it belongs. Examples are Euros
-per month, square meters per household, and persons per Bedarfsgemeinschaft.
+This GEP adds explicit units to TTSIM and GETTSIM. Units are attached to policy
+functions, parameters, input columns, automatically generated calculations, rounding
+rules, and results. A unit records what a number measures and how it is expressed. For
+example, it can distinguish:
 
-TTSIM uses these declarations as a **bounded dimensional linter**. During policy-
-environment assembly, it evaluates supported policy-function expressions with
-unit-carrying placeholders and rejects incompatible arithmetic. It can detect, for
-example, addition of a monthly monetary amount to a yearly monetary amount, use of a
-currency stock as a branch condition, or a function that declares monthly income but
-returns wealth multiplied by a bare share.
+- Euro per month from Euro per year;
+- wealth from monthly income;
+- total rent from rent per square meter; and
+- a household total from a total for a Bedarfsgemeinschaft.
 
-The checker is not a proof of arbitrary Python, data alignment, legal correctness, or
-semantic correctness among dimensionless values. In particular, it does not generally
-distinguish shares, identifiers, categories, counts, and rates that have the same Pint
-dimensionality. Grouping-level denominators are a deliberately restricted guard for
-measurable group quantities, not a complete model of relational data grain. Operations
-whose unit-relevant behavior the checker cannot derive must fail closed or be covered by
-an explicit, reported exception.
+TTSIM uses these declarations to review the unit calculations in a policy environment.
+When it assembles the environment, it runs supported policy formulas with test values
+that carry units. It rejects operations that do not make sense, such as adding a monthly
+amount to an annual amount or using an amount of money as the condition in an `if`
+statement.
 
-Unit declarations also make historical currency handling explicit. Each policy regime
-has exactly one statutory computation currency. GETTSIM evaluates statutory parameters
-and rounding rules in that currency, converts monetary input at the boundary, and
-converts computed results only after statutory computation and rounding.
+The check has clear limits. It does not establish that a formula implements the law
+correctly, that observations are matched to the right people, or that every physically
+dimensionless number has the right economic meaning. A share, an identifier, a category
+code, and a count are all dimensionless in the physical sense. The checker can
+distinguish them only in the special cases described in this GEP. Likewise, a household
+marker helps with selected calculations involving household totals and head counts, but
+it does not replace checks of data layout, merge keys, or group membership. If TTSIM
+does not know how an operation affects units, it must reject the operation or record an
+explicit exception.
+
+The unit declarations also set one rule for historical currencies. Each policy regime is
+calculated in the currency used by the law in that regime. GETTSIM converts monetary
+input into that statutory currency before the calculation and converts results into the
+user's requested currency only after the statutory calculation and rounding are
+complete.
 
 ## Normative language
 
@@ -54,75 +60,81 @@ capital letters.
 
 ## Motivation and scope
 
-Four problems motivate this GEP.
+This GEP addresses four recurring sources of mistakes.
 
-1. **Arithmetic is not dimensionally validated.** TTSIM currently manipulates ordinary
-   Python, NumPy, and JAX values. A calculation can therefore add total rent to rent per
-   square meter or return a stock from a function that declares a monthly flow.
-1. **Selected grouping mistakes are not caught.** A household total and a
-   Bedarfsgemeinschaft total can be combined without an explicit conversion. A missing
-   division by a group head count can likewise remain invisible.
-1. **Historical currencies need one explicit convention.** Some historical monetary
-   parameters are specified in Deutsche Mark and others in Euro. Statutory numerical
-   values must not be silently rewritten merely to make every policy year use the same
-   denomination.
-1. **Reference-period conversions are maintained separately.** GETTSIM already converts
-   between annual, quarterly, monthly, weekly, and daily flows. The ordinary conversion
-   ratios should come from the same unit system that checks the policy expressions.
+1. **The same storage type can represent different quantities.** In a DataFrame, a
+   `float` column may contain wealth, monthly earnings, annual earnings, a share, or
+   square meters. Python, NumPy, and JAX normally allow arithmetic between these columns
+   even when the economic quantities are not compatible.
+1. **Group calculations can use the wrong level.** A household total can accidentally be
+   combined with a Bedarfsgemeinschaft total. A formula can also forget to divide a
+   group total by the number of people in the group. These mistakes are similar to using
+   a variable produced by `egen total(), by(hh_id)` as if it were a person-level value.
+1. **Historical policy parameters use different currencies.** German statutes contain
+   both Deutsche-Mark and Euro amounts. Rewriting all historical values into one
+   currency would obscure the values stated in the law and can change formulas that
+   contain currency-dependent coefficients.
+1. **Period conversions should use one common rule.** GETTSIM already converts flows
+   between years, quarters, months, weeks, and days. The same unit system should supply
+   these standard ratios and check that the conversions are dimensionally possible.
 
-The adopted design is intentionally narrower than a general static value-type system. It
-covers:
+The design is deliberately focused. It uses [Pint](https://pint.readthedocs.io), a
+Python library for calculations with units, and covers:
 
-- compositional Pint units for physical quantities, reference periods, and restricted
-  grouping-level markers;
-- declarations on policy functions, policy inputs, parameters, schedules, structured
-  values, generated nodes, aggregations, rounding rules, and optional input tags;
-- bounded body checking for the documented expression subset;
-- explicit handling of truth contexts, `xnp.where`, joins, and unsupported reductions;
-- validation over every distinct function, parameter, and statutory-currency regime;
-- one statutory computation currency per policy regime; and
-- separate reporting of declarations, checked bodies, casts, and whole-body opt-outs.
+- physical units, reference periods, and a limited set of group markers built with Pint;
+- unit declarations for policy functions, inputs, parameters, schedules, structured
+  values, generated nodes, aggregations, rounding rules, and optionally tagged input
+  data;
+- checking the supported expressions inside policy functions;
+- explicit rules for conditions, `xnp.where`, joins, and reductions;
+- checking every relevant combination of functions, parameters, and statutory currency;
+- one statutory computation currency in each policy regime; and
+- separate reporting of inferred units, generated rules, local unit assertions, and
+  unchecked function bodies.
 
-The GEP does **not** attempt to establish:
+The GEP does **not** check:
 
-- that a policy formula implements the statute or an economic model correctly;
-- semantic distinctions among all dimensionless values, such as an identifier, share,
-  category, probability, count, or unrestricted scalar;
-- nominal key domains, uniqueness, join cardinality, row alignment, broadcasting
-  provenance, or general storage grain;
-- numerical stability, finiteness, overflow safety, or economically admissible ranges;
-- correctness of arbitrary Python or third-party functions; or
-- statutory day-count, partial-period, or compounding conventions beyond the existing
-  generated reference-period conversions.
+- whether a formula is a correct interpretation of a statute or economic model;
+- every difference between dimensionless values such as identifiers, shares,
+  probabilities, categories, counts, and rates;
+- whether merge keys refer to the same kind of identifier, are unique, or produce the
+  intended number of matches;
+- whether columns have the intended observations, sorting, alignment, or broadcasting;
+- numerical stability, finite values, overflow, or economically sensible ranges;
+- arbitrary Python or third-party functions for which TTSIM has no unit rule; or
+- legal conventions for day counts, partial periods, and compounding beyond the existing
+  automatic period conversions.
 
-The naming conventions and generated reference-period conversions in
-{ref}`GEP 1 <gep-1>`, grouping declarations in {ref}`GEP 2 <gep-2>`, DAG and aggregation
-concepts in {ref}`GEP 4 <gep-4>`, rounding in {ref}`GEP 5 <gep-5>`, and runtime
-user/canonical type split in {ref}`GEP 9 <gep-9>` remain in force.
+The naming rules and automatic period conversions in {ref}`GEP 1 <gep-1>`, group
+identifiers in {ref}`GEP 2 <gep-2>`, calculation-graph (DAG) and aggregation concepts in
+{ref}`GEP 4 <gep-4>`, rounding in {ref}`GEP 5 <gep-5>`, and runtime data types in
+{ref}`GEP 9 <gep-9>` continue to apply.
 
 (gep-10-guarantee)=
 
 ### What a successful check means
 
-A successful GEP-10 body check means only the following:
+When TTSIM successfully checks the calculations inside a policy function—called a body
+check in this GEP—it means:
 
-> For every explored path through a supported policy-function body, every operation for
-> which TTSIM supplies a unit rule is dimensionally compatible, and every explored
-> return value is compatible with the function's declared unit.
+> For every case of the policy formula that TTSIM examined, each supported operation
+> used compatible units, and the result had the unit declared by the function.
 
-This statement is conditional on the declared units of inputs and parameters being
-correct, on the checker reaching every relevant path within its documented bounds, and
-on every called operation being represented by a faithful validator stand-in.
+This conclusion depends on three conditions:
 
-A successful environment check MUST NOT be described simply as a proof that “all
-functions are unit-correct.” Documentation and CI output MUST distinguish at least:
+1. the units declared for inputs and parameters are correct;
+1. the checker reaches all relevant cases within its documented limits; and
+1. TTSIM's checking version of each operation represents the real operation faithfully.
 
-- required declarations that were resolved;
-- function bodies that were checked;
-- generated nodes whose units were derived from a documented rule;
+A successful check MUST NOT be summarized as “all functions are unit-correct.”
+Documentation and continuous-integration output MUST report at least:
+
+- declarations that were found and resolved;
+- policy-function bodies that were checked;
+- automatically generated nodes whose units follow a documented rule;
 - local uses of `cast_ttsim_unit`;
-- function bodies excluded with `verify_units=False`; and
-- bodies rejected because they use an unsupported operation.
+- bodies excluded with `verify_units=False`; and
+- bodies that could not be checked because they use an unsupported operation.
 
 (gep-10-usage)=
 
@@ -130,10 +142,9 @@ functions are unit-correct.” Documentation and CI output MUST distinguish at l
 
 ### Users of existing policy environments
 
-Most users continue to call `main()` with ordinary arrays, mappings, or a DataFrame.
-Users may provide a `data_currency` argument to specify the denomination assumed for
-unannotated monetary input and requested for computed monetary results. The default in
-GETTSIM remains Euro.
+Most users continue to call `main()` with ordinary arrays, mappings, or a DataFrame. The
+optional `data_currency` argument states the currency of untagged monetary input and the
+currency requested for monetary results. In GETTSIM it defaults to Euro.
 
 ```python
 results = main(
@@ -143,17 +154,18 @@ results = main(
 )
 ```
 
-For this run, GETTSIM:
+For this example, GETTSIM:
 
-1. identifies Deutsche Mark as the statutory computation currency on 1999-01-01;
-1. converts currency-denominated input from Euro to Deutsche Mark;
-1. evaluates the policy using statutory Deutsche-Mark parameters and rounding rules;
-1. performs statutory rounding before presentation conversion; and
-1. converts computed monetary results back to Euro.
+1. recognizes Deutsche Mark as the currency of the law on 1999-01-01;
+1. converts monetary input from Euro to Deutsche Mark;
+1. calculates the policy with the Deutsche-Mark parameters and rounding rules stated in
+   the law;
+1. performs statutory rounding in Deutsche Mark; and
+1. converts the calculated monetary results back to Euro.
 
-Requested raw input columns are returned unchanged. Requested parameters retain their
-statutory currency. A policy function never receives simultaneous DM- and
-EUR-denominated monetary quantities within one policy regime.
+If users request an input column as part of the output, GETTSIM returns that input
+column unchanged. Requested parameters remain in their statutory currency. Within one
+policy regime, a policy function does not receive a mixture of DM and EUR amounts.
 
 (gep-10-trees)=
 
@@ -161,10 +173,9 @@ EUR-denominated monetary quantities within one policy regime.
 
 ### Unit-annotated data
 
-Input unit annotations are optional. They are useful when users want to state the source
-currency and reference period of their data. When this input mode is selected, every
-leaf is wrapped in `UnitAnnotatedColumn`, including identifiers and dimensionless
-columns.
+Users may optionally attach a unit to every input column. This is useful when a dataset
+comes with a known currency and reference period. In this input mode, every leaf is a
+`UnitAnnotatedColumn`, including identifiers and other dimensionless columns.
 
 ```python
 from gettsim import InputData, MainTarget, TTTargets, main
@@ -197,34 +208,35 @@ results = main(
 )
 ```
 
-The boundary behavior is deliberately limited and MUST be described exactly:
+The limits of the first implementation MUST be described exactly. It performs the
+following checks at the data boundary:
 
-- a tag built from an unknown unit token fails;
-- the tag's period MUST match the column's GEP-1 time suffix exactly;
-- a concrete source currency may differ from the run's statutory currency and is
-  converted; and
-- other physical dimensions and grouping levels are not, in this first implementation,
-  compared with the corresponding node declaration at the input boundary.
+- an unknown unit name is an error;
+- the period in the unit MUST agree exactly with the GEP-1 suffix of the column name;
+- a stated source currency may differ from the statutory currency and is converted; and
+- other physical dimensions and group levels are not yet compared with the unit declared
+  for the policy node.
 
-Thus a `_m` column tagged per year fails, but the boundary alone does not establish that
-an unsuffixed age column was not incorrectly tagged as currency. The function and node
-declarations remain the source of the computation's units. Unit-annotated input is a
-currency-and-period guard, not a fully typed data interface.
+For example, a column ending in `_m` but tagged as an annual flow is rejected. The
+boundary check alone does not detect that an age column was accidentally tagged as
+currency. The declarations on policy inputs and functions remain the authoritative units
+used in the calculation. In this version, tagged input protects currency and period; it
+is not a complete variable-dictionary check.
 
-When `MainTarget.results.tree_with_unit_annotations` is requested, computed result
-leaves carry their resolved unit and concrete output currency. Ordinary result targets
-continue to return bare values.
+When users request `MainTarget.results.tree_with_unit_annotations`, calculated results
+include their resolved unit and output currency. The ordinary result targets continue to
+return plain numerical values.
 
 ### Contributors and users extending policy environments
 
-Contributors adding functions to a policy environment declare units on policy functions,
+Anyone who adds or changes a policy environment declares units for policy functions,
 policy inputs, parameters, rounding specifications, and hand-written aggregations.
 
 #### Policy functions
 
-A policy function declares the unit of its return value. TTSIM checks the supported
-parts of the function body against that declaration when the policy environment is
-assembled.
+A policy function declares the unit of the value it returns. When TTSIM assembles the
+policy environment, it checks the supported calculations in the function against this
+declaration.
 
 ```python
 @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_BG)
@@ -243,11 +255,13 @@ def betrag_m_bg(
     return regelsatz_m_bg + mehrbedarf_m_bg
 ```
 
-`CURRENCY` is abstract in code-side declarations. At a policy date, TTSIM replaces it
-with the regime's concrete statutory currency. The `_m` suffix must agree with
-`PER_MONTH`, and `_bg` must agree with `PER_BG` where GEP 1 requires the suffix.
+In Python declarations, `CURRENCY` means “the currency used by the law at this policy
+date.” TTSIM replaces it with the concrete statutory currency. The `_m` suffix must
+agree with `PER_MONTH`, and `_bg` must agree with `PER_BG` whenever GEP 1 requires these
+suffixes.
 
-The following function is rejected because the operands have different physical units:
+The next function is rejected because one argument is a total monthly amount and the
+other is a monthly amount per square meter:
 
 ```python
 @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
@@ -270,8 +284,9 @@ def incorrect_amount_m(
 
 #### Stocks, flows, shares, and rates
 
-A stock has no reference-period denominator. A flow has one. Multiplication by a bare
-share preserves the stock/flow status of the other operand.
+A stock is measured at a point in time and has no period in its unit. A flow is measured
+per year, month, week, or day. Multiplying either by a simple share does not change
+whether it is a stock or a flow.
 
 ```python
 @policy_input(unit=TTSIMUnit.CURRENCY)
@@ -283,10 +298,10 @@ def retained_wealth(wealth: float) -> float:
     return 0.8 * wealth
 ```
 
-The result is a stock because `0.8` is dimensionless. Declaring `retained_wealth` as
-`CURRENCY.PER_MONTH` would be false.
+The result is still wealth because `0.8` is a dimensionless share. Declaring the result
+as `CURRENCY.PER_MONTH` would be incorrect.
 
-A rate that turns a stock into a flow carries an inverse-period unit:
+A rate that converts a stock into a flow includes a period denominator:
 
 ```python
 @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_YEAR)
@@ -301,23 +316,21 @@ def interest_income_y(
     return wealth * interest_rate_y
 ```
 
-The inference is
+The unit calculation is:
 
 ```text
 CURRENCY * (1 / year) = CURRENCY / year.
 ```
 
-The unit system does not infer financial compounding conventions. A linear annual rate
-may be converted to a monthly flow with the ordinary generated period ratio. An
-effective annual return that requires `(1 + r_y) ** (1 / 12) - 1`, a continuously
-compounded rate, or a statute-specific proration MUST use an explicit conversion
-function. Units can establish that a rate is per year; they cannot determine the
-intended rate convention.
+Units do not determine how a financial rate compounds. A linear annual rate can use the
+ordinary generated conversion to a monthly flow. An effective annual rate that requires
+`(1 + r_y) ** (1 / 12) - 1`, a continuously compounded rate, or a legal proration rule
+MUST use an explicit conversion function. The unit tells us that the rate is annual; it
+does not tell us which financial convention applies.
 
 #### Parameters
 
-Parameter files record the concrete currency and period in which a statute specifies a
-value.
+Parameter files state the concrete currency and period in which the law gives a value.
 
 ```yaml
 einkommensgrenze_m:
@@ -327,29 +340,29 @@ einkommensgrenze_m:
     value: 1000.0
 ```
 
-Currency-denominated parameters MUST use a concrete currency. Validation requires that
-currency to equal the statutory computation currency for every policy regime in which
-the parameter entry is active.
+A monetary parameter MUST name a concrete currency. For every date on which the
+parameter entry is used, that currency must be the statutory currency of the policy
+regime.
 
 ## Backward compatibility
 
-- Bare arrays and the DataFrame or mapping input interfaces remain supported.
-- `data_currency` defaults to `EUR`, so current-policy Euro input and output retain
-  their existing denomination.
-- The former `reference_period` and `reference_level` fields are replaced by the
-  compositional unit, for example `EUR_PER_YEAR_PER_FG`.
+- Ordinary arrays, mappings, and DataFrame inputs remain supported.
+- `data_currency` defaults to `EUR`, so present-day Euro input and output keep their
+  current denomination.
+- One combined unit name such as `EUR_PER_YEAR_PER_FG` replaces the separate
+  `reference_period` and `reference_level` fields.
 - Existing policy functions, policy inputs, parameter files, hand-written aggregations,
-  and monetary rounding specifications require unit declarations.
-- `DIMENSIONLESS` remains the common unit for shares, rates without a period, IDs,
-  categories, and other physically dimensionless values. This GEP deliberately does not
-  introduce a public semantic-kind hierarchy.
-- `verify_units=False` remains available for one body, but every use is reported as an
-  unchecked body. It MUST NOT be counted as body verification.
-- `cast_ttsim_unit` remains available as a local assertion. Every use is reported
-  separately from inferred operations.
-- Unit validation cannot be disabled globally. `include_fail_nodes=False` may skip
-  selected fail nodes during environment assembly and annotated-input processing, but
-  malformed declarations remain errors.
+  and monetary rounding rules need unit declarations.
+- `DIMENSIONLESS` continues to cover shares, rates without a period, identifiers,
+  categories, and other physically dimensionless numbers. This GEP does not add a
+  separate public unit category for every economic meaning.
+- `verify_units=False` may exclude one function body from checking, but the report lists
+  it as unchecked. It MUST NOT count as a checked body.
+- `cast_ttsim_unit` remains available for a local unit assertion. The report lists each
+  use separately from units inferred by TTSIM.
+- Unit validation cannot be switched off for an entire policy environment.
+  `include_fail_nodes=False` may skip selected failure nodes while the environment or
+  tagged input is processed, but invalid declarations are still errors.
 
 ## Detailed description
 
@@ -357,55 +370,58 @@ the parameter entry is active.
 
 ### Design principles
 
-1. **Pint handles physical and reference-period algebra.** TTSIM does not replace Pint
-   with a general value-type system.
-1. **Grouping markers have a narrow purpose.** They catch selected group-total,
-   head-count, and group-indicator mistakes. They do not model arbitrary row grain.
-1. **Claims follow implementation.** A bounded placeholder evaluation is called a
-   linter, not a proof of arbitrary Python.
-1. **Supported operations inspect every unit-relevant operand.** A stand-in MUST NOT
-   discard a condition, fallback, key, period, or other operand and still count the body
-   as checked.
-1. **Unsupported grain-changing operations fail closed.** In-body reductions are not
-   assigned an unchanged unit when the checker lacks axis metadata.
-1. **Every distinct policy regime is checked.** Function boundaries alone are not an
-   exhaustive date partition; parameter and statutory-currency changes matter too.
-1. **Exceptions remain visible.** A declaration, cast, generated rule, checked body, and
-   whole-body opt-out are different facts and are reported separately.
-1. **One policy regime uses one statutory currency.** Mixed statutory currencies never
-   enter the same policy-function body.
+1. **Use Pint for ordinary unit arithmetic.** Pint handles physical units and reference
+   periods. TTSIM adds only the policy-specific rules described here.
+1. **Use group markers for selected group calculations.** They help find mistakes in
+   totals, head counts, and indicators. They do not describe every aspect of the data's
+   observation level.
+1. **Describe the check accurately.** TTSIM checks a defined set of expressions. It does
+   not prove arbitrary Python code correct.
+1. **Check every relevant argument.** If a condition, fallback value, key, period, or
+   other argument can affect the unit of a supported operation, the checker MUST inspect
+   it.
+1. **Reject unsupported changes of observation level.** If an operation may change what
+   a row represents and TTSIM lacks the necessary array or grouping information, the
+   checker must not simply keep the old unit.
+1. **Check every distinct policy regime.** A regime may change because a function,
+   parameter, rounding rule, or statutory currency changes.
+1. **Keep exceptions visible.** A declaration, a generated rule, a checked body, a local
+   cast, and a whole-body opt-out provide different levels of assurance and are reported
+   separately.
+1. **Use one statutory currency per regime.** Monetary values in different statutory
+   currencies never enter the same policy-function calculation.
 
 (gep-10-terminology)=
 
 ### Terminology
 
-| Term               | Meaning                                                                                                                                                |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| quantity           | A value with a declared unit, such as income, age, a share, or a head count.                                                                           |
-| base               | The numerator of a compositional unit, such as `CURRENCY`, `DIMENSIONLESS`, or `YEARS`.                                                                |
-| period             | A denominator that distinguishes a flow or rate from a stock or bare quantity, such as `MONTH` or `YEAR`.                                              |
-| grouping level     | A restricted denominator identifying the group to which a measurable group quantity, count, or indicator belongs. It is not a complete row-grain type. |
-| bare               | A quantity without a grouping-level denominator. Personal quantities and physically dimensionless shares or rates are normally bare.                   |
-| stock              | A quantity without a period denominator, such as wealth.                                                                                               |
-| flow               | A quantity with a period denominator, such as income per month.                                                                                        |
-| rate               | A multiplicative quantity. A rate that turns a stock into a flow carries an inverse-period denominator.                                                |
-| calendar point     | A coordinate such as a calendar year.                                                                                                                  |
-| calendar ordinal   | A bounded coordinate within a wider context, such as month of year or day of month.                                                                    |
-| calendar duration  | A length such as years, months, or days.                                                                                                               |
-| statutory currency | The one concrete currency in which a policy regime's monetary parameters and rounding rules are written.                                               |
-| data currency      | The currency assumed for unannotated input and requested for computed output.                                                                          |
-| body check         | Bounded evaluation of a supported function body with unit-carrying placeholders.                                                                       |
-| cast               | A local assertion that replaces the inferred unit of one expression during body checking.                                                              |
-| opt-out            | `verify_units=False` on one body; its declaration remains a consumer contract, but the body is not checked.                                            |
+| Term               | Meaning                                                                                                                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| quantity           | A value with a unit, such as income, age, a share, or a head count.                                                                                                                 |
+| base               | What is measured in the numerator, such as `CURRENCY`, `DIMENSIONLESS`, or `YEARS`.                                                                                                 |
+| period             | A denominator such as `MONTH` or `YEAR` that identifies a flow or rate.                                                                                                             |
+| grouping level     | A denominator such as `HH` or `BG` that marks selected amounts, counts, or indicators belonging to that group. It is not a complete description of the dataset's observation level. |
+| bare               | A quantity without a grouping denominator. Person-level quantities and ordinary shares or rates are usually bare.                                                                   |
+| stock              | A quantity without a period denominator, such as wealth.                                                                                                                            |
+| flow               | A quantity with a period denominator, such as monthly income.                                                                                                                       |
+| rate               | A multiplier. A rate that converts a stock to a flow has a period denominator.                                                                                                      |
+| calendar point     | A location on a calendar, such as the year 2025.                                                                                                                                    |
+| calendar ordinal   | A position within a larger calendar unit, such as month 2 or day 15.                                                                                                                |
+| calendar duration  | A length of time, such as 18 years or 3 months.                                                                                                                                     |
+| statutory currency | The currency in which the law states the active parameters and rounding rules.                                                                                                      |
+| data currency      | The currency assumed for untagged input and requested for calculated output.                                                                                                        |
+| body check         | Running supported policy formulas with unit-carrying test values and comparing the result with the declared unit.                                                                   |
+| cast               | A local assertion that tells the checker to use a stated unit for one expression.                                                                                                   |
+| opt-out            | `verify_units=False` on one function. Its output declaration still applies, but its calculations are not checked.                                                                   |
 
 (gep-10-valuespec)=
 
 (gep-10-vocabulary)=
 
-### Compositional unit vocabulary
+### How unit names are built
 
-A unit consists of one base followed by at most one denominator from each supported
-category. Components have a fixed order.
+A declaration begins with one base unit. It may then add no more than one physical
+denominator, one period denominator, and one group denominator, in that order.
 
 ```text
 base        := CURRENCY
@@ -431,11 +447,11 @@ unit        := base
              | base _PER_ physical _PER_ period _PER_ level
 ```
 
-Each denominator category may appear at most once and must follow the order shown above.
-For example, `EUR_PER_MONTH_PER_YEAR` is invalid, as is `EUR_PER_BG_PER_MONTH`; use
-`EUR_PER_MONTH_PER_BG`.
+The fixed order makes declarations consistent and easy to read. For example,
+`EUR_PER_MONTH_PER_YEAR` is invalid because it contains two period denominators.
+`EUR_PER_BG_PER_MONTH` is also invalid; the correct order is `EUR_PER_MONTH_PER_BG`.
 
-In Python, declarations are constructed by chaining attributes:
+In Python, units are built by chaining attributes:
 
 ```python
 TTSIMUnit.CURRENCY.PER_MONTH.PER_BG
@@ -445,42 +461,41 @@ TTSIMUnit.DIMENSIONLESS.PER_YEAR
 TTSIMUnit.HOURS.PER_WEEK
 ```
 
-The YAML spelling joins the same components with `_PER_`.
+YAML uses the same components joined by `_PER_`.
 
 #### Common declarations
 
-| Declaration                           | Resolved dimensionality       | Example                                             |
-| ------------------------------------- | ----------------------------- | --------------------------------------------------- |
-| `CURRENCY_PER_MONTH`                  | `CURRENCY / month`            | personal monthly income                             |
-| `CURRENCY_PER_MONTH_PER_BG`           | `CURRENCY / month / [bg]`     | monthly amount assigned to a Bedarfsgemeinschaft    |
-| `CURRENCY`                            | `CURRENCY`                    | wealth stock                                        |
-| `DIMENSIONLESS`                       | dimensionless                 | share, ID, category, or bare rate                   |
-| `DIMENSIONLESS_PER_YEAR`              | `1 / year`                    | linear annual rate applied to a stock               |
-| `DIMENSIONLESS_PER_BG`                | `1 / [bg]`                    | persons in, or indicator for, a Bedarfsgemeinschaft |
-| `HOURS_PER_WEEK`                      | `[hours] / week`              | weekly working hours                                |
-| `CURRENCY_PER_HOURS`                  | `CURRENCY / [hours]`          | hourly wage                                         |
-| `CURRENCY_PER_SQUARE_METER_PER_MONTH` | `CURRENCY / meter**2 / month` | monthly rent ceiling per square meter               |
-| `YEARS`                               | year duration                 | age or another duration in years                    |
-| `CALENDAR_YEAR`                       | calendar-year point           | birth year                                          |
-| `CALENDAR_MONTH`                      | month-of-year ordinal         | February represented as `2`                         |
+| Declaration                           | Meaning                                      | Example                                                        |
+| ------------------------------------- | -------------------------------------------- | -------------------------------------------------------------- |
+| `CURRENCY_PER_MONTH`                  | currency per month                           | personal monthly income                                        |
+| `CURRENCY_PER_MONTH_PER_BG`           | currency per month for a Bedarfsgemeinschaft | monthly amount assigned to a Bedarfsgemeinschaft               |
+| `CURRENCY`                            | a currency stock                             | wealth                                                         |
+| `DIMENSIONLESS`                       | no physical unit                             | share, identifier, category, or rate without a period          |
+| `DIMENSIONLESS_PER_YEAR`              | one per year                                 | linear annual rate applied to a stock                          |
+| `DIMENSIONLESS_PER_BG`                | count or indicator for a Bedarfsgemeinschaft | number of people in the group or a group eligibility indicator |
+| `HOURS_PER_WEEK`                      | working hours per week                       | weekly working hours                                           |
+| `CURRENCY_PER_HOURS`                  | currency per working hour                    | hourly wage                                                    |
+| `CURRENCY_PER_SQUARE_METER_PER_MONTH` | currency per square meter per month          | monthly rent ceiling per square meter                          |
+| `YEARS`                               | a duration measured in years                 | age                                                            |
+| `CALENDAR_YEAR`                       | a particular calendar year                   | birth year                                                     |
+| `CALENDAR_MONTH`                      | a month-of-year number                       | February represented as `2`                                    |
 
-`CURRENCY` is an abstract code-side placeholder. TTSIM resolves it to the statutory
-currency for the policy date. Parameters, rounding specifications, and annotated input
-use concrete currencies where their denomination is fixed.
+`CURRENCY` is used in Python when the concrete currency depends on the policy date.
+TTSIM resolves it to the statutory currency. Parameters, rounding rules, and tagged
+input use a concrete currency whenever their denomination is already known.
 
 (gep-10-kinds)=
 
-#### Dimensionless semantic distinctions
+#### Dimensionless values with different economic meanings
 
-`DIMENSIONLESS` is deliberately not a semantic top type with a complete operation
-algebra. It is the physical unit shared by several meanings, including shares,
-identifiers, categories, indicators, counts, and bare rates. GEP 10 validates only the
-additional cases stated explicitly, such as truth compatibility and restricted
-group-level count or indicator declarations.
+Several economically different values have no physical unit. Examples are a marginal tax
+rate, a probability, a person identifier, a category code, and a number of people. All
+use `DIMENSIONLESS` unless this GEP gives a more specific rule, such as a period on a
+rate or a group marker on a known count or indicator.
 
-A successful dimensional check therefore does not prove that an identifier was not
-multiplied by a share or that two dimensionless IDs belong to the same nominal domain.
-Adding those distinctions requires a separate semantic or relational type proposal.
+A successful unit check therefore does not show that an identifier was never multiplied
+by a share or that two identifiers refer to the same kind of entity. Such checks would
+require a separate system for economic meaning and data relations.
 
 (gep-10-subject-index)=
 
@@ -488,30 +503,29 @@ Adding those distinctions requires a separate semantic or relational type propos
 
 ### Grouping levels
 
-GETTSIM has a person level, identified by `p_id`, and grouping levels identified by
-`*_id` columns. Examples include households (`hh`), Familiengemeinschaften (`fg`),
-Bedarfsgemeinschaften (`bg`), tax units (`sn`), Einsatzgemeinschaften (`eg`),
-Ehegemeinschaften (`ehe`), and wohngeldrechtliche Teilhaushalte (`wthh`). See
-{ref}`GEP 2 <gep-2>`.
+GETTSIM stores one row per person and identifies that person with `p_id`. Columns such
+as `hh_id`, `fg_id`, `bg_id`, `sn_id`, `eg_id`, `ehe_id`, and `wthh_id` identify groups.
+See {ref}`GEP 2 <gep-2>`.
 
-A policy package registers its grouping levels with its unit system. Each level gains a
-`PER_<LEVEL>` builder step and a separate Pint base dimension. There is no person
-dimension: a person quantity is bare.
+A policy package registers its group levels in the unit system. This creates a
+`PER_<LEVEL>` component for each group. TTSIM treats the registered levels as different
+units, so a household (`HH`) cannot be substituted for a Bedarfsgemeinschaft (`BG`).
+There is no `PER_PERSON` component: a person-level amount has no group denominator.
 
 #### What a group marker means
 
-A grouping-level denominator is permitted for a quantity that is both:
+A group marker may be used when a value is:
 
-1. a property calculated or assigned at the target group; and
-1. a measurable amount, count, or boolean indicator for which the supported group
-   arithmetic below is meaningful.
+1. calculated or assigned for a particular target group; and
+1. an amount, count, or yes/no indicator for which the group calculations below make
+   sense.
 
-Examples include monthly household rent, square meters per household, persons per
+Examples are total monthly rent per household, square meters per household, persons per
 household, and a household eligibility indicator.
 
-The grouping marker is **not** attached merely because a value happens to be stored once
-per group. In particular, physically dimensionless shares and ordinary multiplicative
-rates remain bare:
+A group marker is not added merely because a value is stored once per group or repeated
+on every person in the group. In particular, shares, ordinary rates, and identifiers
+remain dimensionless without a group denominator:
 
 ```text
 housing-cost share of a household     -> DIMENSIONLESS
@@ -519,45 +533,47 @@ annual interest rate for a household  -> DIMENSIONLESS_PER_YEAR
 household identifier                  -> DIMENSIONLESS
 ```
 
-This GEP does not validate the row ownership or alignment of those bare values. That is
-a deliberate limitation rather than a claim that shares or rates lack a group-specific
-interpretation.
+This is similar to the distinction between a variable's economic meaning and the way it
+happens to be stored after a Stata `merge` or `bysort`: repeating a household share on
+all household members does not turn the share into a household total. GEP 10 does not
+check whether such repeated values are aligned with the correct rows.
 
-Declaration validation MUST enforce this restriction. A direct
-`DIMENSIONLESS.PER_<LEVEL>` declaration is accepted only when the producer is known to
-be boolean or count-like from its Python return annotation or from a generated `COUNT`,
-boolean `SUM`, `ANY`, or `ALL` rule. A share, probability, or ordinary rate with a
-grouping marker is rejected regardless of storage dtype. When the available metadata
-cannot distinguish a count or indicator from another dimensionless value, validation
-fails conservatively rather than treating every dimensionless group value as admissible.
+Declaration validation MUST enforce the following restriction. A direct
+`DIMENSIONLESS.PER_<LEVEL>` declaration is allowed only for a function or generated node
+known to return a count or a Boolean indicator. TTSIM learns this from the return type
+or from a generated `COUNT`, Boolean `SUM`, `ANY`, or `ALL` operation. A share,
+probability, or ordinary rate with a group marker is rejected. If TTSIM cannot tell
+whether a physically dimensionless group value is a count or indicator, it MUST reject
+the declaration rather than guess.
 
-#### Restricted group algebra
+#### Restricted group calculations
 
-The checked group algebra is deliberately small.
+TTSIM checks the following group calculations:
 
-1. A bare dimensionless scalar may multiply or divide a group quantity without changing
-   its group marker.
-1. Dividing a group total by a matching group head count cancels the group marker and
-   yields a bare per-person quantity.
-1. Multiplying a bare per-person quantity by a matching group head count acquires the
-   group marker and yields a group total.
-1. Logical operations may combine truth-compatible indicators under the rules in
-   {ref}`Booleans and truth contexts <gep-10-booleans>`. A known boolean indicator may
-   select or mask a same-level quantity through a conditional or `xnp.where`; the
-   condition does not multiply its grouping dimension into the selected value. Direct
-   multiplication may receive the same mask rule only when the producer is known to be
-   boolean.
-1. Generic multiplication or division of two other non-count quantities carrying
-   grouping markers is rejected. This prevents accidental squared grouping dimensions or
-   silent cancellation of two unrelated group properties.
-1. Generic multiplication or division of quantities carrying different grouping levels
-   is rejected.
+1. Multiplying or dividing a group quantity by an ordinary dimensionless scalar keeps
+   the group marker.
+1. Dividing a group total by the matching group head count removes the group marker and
+   gives a person-level amount.
+1. Multiplying a person-level amount by the matching group head count adds the group
+   marker and gives a group total.
+1. Logical operations follow the rules in
+   {ref}`Conditions and Boolean values <gep-10-booleans>`. A known Boolean indicator may
+   select or mask a value at the same group level in a conditional expression or
+   `xnp.where`; its group marker is not multiplied into the selected value. Direct
+   multiplication receives this special mask rule only when the producer is known to be
+   Boolean.
+1. Other multiplication or division between two non-count group quantities is rejected.
+   This avoids results such as “household squared” and accidental cancellation between
+   unrelated group properties.
+1. Multiplication or division between quantities carrying different group markers is
+   rejected.
 
-The implementation MAY track “count-like” provenance internally for generated `COUNT`,
-boolean `SUM`, and explicitly declared head-count producers. This does not create a new
-public unit category.
+TTSIM MAY record internally that a value comes from `COUNT`, Boolean `SUM`, or another
+explicit head-count calculation. This internal information does not create another
+public unit.
 
-A head-count conversion is valid:
+For example, dividing a household rent total by the household head count produces a
+person-level amount:
 
 ```text
 wohnen__bruttokaltmiete_m_hh / anzahl_personen_hh
@@ -565,7 +581,7 @@ wohnen__bruttokaltmiete_m_hh / anzahl_personen_hh
   = CURRENCY / month
 ```
 
-and so is the reverse:
+The reverse calculation produces a tax-unit total:
 
 ```text
 familie__anzahl_personen_sn * sparerfreibetrag_y
@@ -573,31 +589,33 @@ familie__anzahl_personen_sn * sparerfreibetrag_y
   = CURRENCY / year / [sn]
 ```
 
-A policy interpretation that transfers an amount from one group concept to another must
-use a local cast or an explicitly declared aggregation. The unit system does not infer
-membership relations between `[hh]`, `[bg]`, `[eg]`, and other levels.
+If a policy deliberately transfers an amount from one group concept to another, the
+function must use a local cast or an explicitly declared aggregation. TTSIM does not
+infer how households, Bedarfsgemeinschaften, tax units, and other groups overlap.
 
 (gep-10-booleans)=
 
-### Booleans and truth contexts
+### Conditions and Boolean values
 
-The public unit vocabulary does not distinguish every semantic kind of dimensionless
-value. The unit checker therefore establishes **truth compatibility**, not full Boolean
-semantics.
+A condition in a policy formula should represent a yes/no statement. A monthly amount,
+age, or annual rate is not a valid condition merely because Python can treat a non-zero
+number as `True`.
 
-A unit-carrying value is truth-compatible only if it has no physical or period dimension
-and carries at most one permitted grouping-level marker. Python annotations and runtime
-type validation remain responsible for distinguishing actual booleans from IDs, counts,
-shares, and other dimensionless values.
+Because several meanings share `DIMENSIONLESS`, the unit checker applies a narrower rule
+called **truth compatibility**. A value is truth-compatible if it has no physical unit
+and no period, and has at most one permitted group marker. Python annotations and
+runtime validation still determine whether the actual value is a Boolean rather than an
+identifier, count, or share.
 
-The following contexts MUST apply the same truth-compatibility check:
+The same truth-compatibility rule MUST apply to:
 
-- Python `if` and conditional expressions;
-- `bool(value)` as invoked by branch exploration;
-- `not`, `&`, `|`, `^`, and `~` where supported; and
+- Python `if` statements and conditional expressions;
+- `bool(value)` calls made while branches are checked;
+- supported uses of `not`, `&`, `|`, `^`, and `~`; and
 - the `condition` argument of `xnp.where`.
 
-A currency stock, age, annual rate, or monthly amount cannot control a branch:
+The following function is invalid because `wealth` is an amount of money, not a
+condition:
 
 ```python
 @policy_function(unit=TTSIMUnit.CURRENCY)
@@ -605,17 +623,17 @@ def invalid(wealth: float) -> float:
     return wealth if wealth else 0.0
 ```
 
-`xnp.where` MUST check its condition before unifying the two result arms. Refactoring a
-scalar conditional into a vectorized conditional must not remove a unit check.
+`xnp.where` MUST check the condition as well as the two possible results. Rewriting a
+scalar conditional as a vectorized `xnp.where` must not remove this check.
 
-Logical operators preserve a common grouping level when both operands have that level.
-When one operand is bare and one carries a grouping level, or when the levels differ,
-the result is bare because the operation is evaluated row-wise. This rule is a pragmatic
-unit rule and is not a general proof of row alignment.
+When two logical inputs carry the same group marker, the result keeps that marker. If
+one is person-level and one is group-level, or if their group levels differ, the result
+is treated as person-level because the logical operation is evaluated row by row. This
+is a practical unit rule; it does not establish that the underlying rows are aligned.
 
-Ordering comparisons require unit-compatible operands and produce a truth-compatible
-result. Equality remains unit-blind; see
-{ref}`Trade-offs and limitations <gep-10-limitations>`.
+Ordering comparisons such as `<` and `>=` require compatible units and produce a
+truth-compatible result. Equality comparisons do not compare units, for the reasons
+given in {ref}`Trade-offs and limitations <gep-10-limitations>`.
 
 (gep-10-hours)=
 
@@ -623,37 +641,36 @@ result. Equality remains unit-blind; see
 
 #### Working hours
 
-Working hours use a dedicated `[hours]` dimension rather than Pint's calendar-time
-dimension. Otherwise, hours per week would reduce to a dimensionless ratio and could not
-be distinguished from a share.
+Working hours use their own `[hours]` dimension. They are not represented as ordinary
+calendar time. Otherwise, “hours per week” would simplify to a dimensionless fraction
+and could not be distinguished from a share.
 
-`HOURS_PER_WEEK` therefore resolves to `[hours] / [time]`.
+`HOURS_PER_WEEK` therefore means `[hours] / [time]`.
 
 (gep-10-calendar)=
 
-#### Calendar points, durations, and ordinals
+#### Calendar years, durations, and month/day numbers
 
-`CALENDAR_YEAR` is an affine point on the calendar-year axis. `YEARS` is a duration.
-Their supported algebra is:
+A calendar year and a duration in years are different economic variables. The year 2025
+is a point on a calendar; an age of 45 is a distance between two calendar points. The
+supported calculations are:
 
-| Operation                      | Result                 | Example                       |
-| ------------------------------ | ---------------------- | ----------------------------- |
-| point minus point              | duration               | `policy_year - geburtsjahr`   |
-| point plus or minus duration   | point                  | `geburtsjahr + statutory_age` |
-| ordering of two points         | truth-compatible value | `geburtsjahr <= policy_year`  |
-| point plus point               | error                  | adding two birth years        |
-| point times scalar             | error                  | scaling a birth year          |
-| point ordered against duration | error                  | comparing birth year with age |
+| Calculation                            | Result                    | Example                         |
+| -------------------------------------- | ------------------------- | ------------------------------- |
+| calendar year minus calendar year      | duration                  | `policy_year - geburtsjahr`     |
+| calendar year plus or minus duration   | calendar year             | `geburtsjahr + statutory_age`   |
+| ordering two calendar years            | condition (true or false) | `geburtsjahr <= policy_year`    |
+| calendar year plus calendar year       | error                     | adding two birth years          |
+| calendar year times a scalar           | error                     | multiplying a birth year by two |
+| calendar year compared with a duration | error                     | comparing birth year with age   |
 
-Quarter of year, month of year, and day of month are **ordinals**, not context-free
-affine points. `2 CALENDAR_MONTH` means February and `15 CALENDAR_DAY` means the
-fifteenth day within a wider date context. These declaration tokens are nominal ordinal
-markers whose allowed operations are supplied by TTSIM's validator rules; they are not
-ordinary Pint affine-point units. They support equality and ordering within the same
-ordinal axis, but they do not support generic point-plus-duration or point-minus-point
-algebra.
+Quarter of year, month of year, and day of month are positions within a larger calendar
+unit. For example, `2 CALENDAR_MONTH` means February and `15 CALENDAR_DAY` means the
+fifteenth day of a month. TTSIM supplies specific checking rules for these values rather
+than treating them as ordinary Pint units. They may be compared with values on the same
+calendar scale, but they do not support general addition and subtraction with durations.
 
-In particular, the unit system does not define:
+In particular, the unit system does not assign a meaning to:
 
 ```text
 December + 2 months
@@ -661,23 +678,26 @@ December + 2 months
 February 29 without a year and calendar
 ```
 
-Framework-provided `policy_quarter`, `policy_month`, and `policy_day` values MAY remain
-represented as dimensionless ordinals. This GEP does not claim to validate their
-complete calendar semantics. A future calendar proposal may add explicit range and
-context rules without changing the physical-unit model adopted here.
+Framework values such as `policy_quarter`, `policy_month`, and `policy_day` MAY remain
+dimensionless ordinals. This GEP does not check their complete calendar meaning. A later
+calendar proposal may add ranges and calendar context without changing the physical unit
+system defined here.
 
-Reference-period conversion for flows is separate from calendar arithmetic. Converting
-`CURRENCY_PER_YEAR` to `CURRENCY_PER_MONTH` is not calendar-point addition.
+Converting an annual flow into a monthly flow is separate from calendar arithmetic.
+`CURRENCY_PER_YEAR` to `CURRENCY_PER_MONTH` uses a reference-period ratio; it does not
+add or subtract calendar points.
 
 (gep-10-parameters)=
 
 ### Parameter declarations
 
-Units are declared at parameter definition. Declaration shape follows parameter shape.
+A parameter declares its unit where the parameter is defined. The shape of the unit
+declaration follows the shape of the parameter value.
 
 #### Scalars and dictionaries
 
-A scalar parameter and a dictionary with homogeneous leaves use one unit declaration.
+A scalar parameter and a dictionary whose leaves all have the same unit use one unit
+declaration.
 
 ```yaml
 satz:
@@ -696,7 +716,7 @@ satz_nach_kindanzahl:
     2: 250.0
 ```
 
-A dictionary with heterogeneous leaves uses a mapping from leaf keys to units.
+A dictionary containing different kinds of quantities declares the unit of each leaf.
 
 ```yaml
 schedule:
@@ -709,19 +729,20 @@ schedule:
     max_age: 18
 ```
 
-The unit mapping is the union of leaves that can occur over the parameter's date range.
-At one policy date, validation requires declarations only for leaves present in the
-resolved value.
+The unit mapping contains every leaf that can appear during the parameter's history. At
+a particular date, only the leaves present in the resolved value need declarations.
 
-A dated entry may replace or introduce a unit declaration. The most recent declaration
-at or before the policy date applies. A dated per-leaf mapping replaces the previous
-mapping completely and declares every leaf present at that date.
+A dated entry may replace or add a unit declaration. The latest declaration on or before
+the policy date applies. If a dated entry supplies a new mapping of leaf units, that
+mapping replaces the earlier mapping completely and must declare every leaf present on
+that date.
 
 (gep-10-schedules)=
 
-#### Mapping parameters
+#### Schedules and lookup tables
 
-A schedule or lookup table declares input and output axes rather than one scalar unit.
+A schedule or lookup table has an input unit and an output unit. This is the same idea
+as stating the unit of both the running variable and the result of a tax schedule.
 
 ```yaml
 freibetrag_bei_behinderung_gestaffelt_y:
@@ -731,17 +752,16 @@ freibetrag_bei_behinderung_gestaffelt_y:
   # Intervals omitted.
 ```
 
-The parameter schema rejects `unit:` on a mapping type that requires `input_unit:` and
-`output_unit:`. A time suffix in the parameter name describes the output axis and must
-agree with `output_unit`.
+For a parameter type that requires `input_unit:` and `output_unit:`, the schema rejects
+a single `unit:` declaration. A time suffix in the parameter name describes the output
+and must agree with `output_unit`.
 
 #### Parameter functions
 
-A `@param_function` converts a raw YAML parameter declared with
-`type: require_converter` into the object used by policy functions. Its unit declaration
-describes the converted result.
+A `@param_function` converts a raw YAML parameter of type `require_converter` into the
+object used by policy functions. Its declaration describes the converted object.
 
-Schedule-producing parameter functions declare input and output units:
+A parameter function that produces a schedule declares both axes:
 
 ```python
 @param_function(
@@ -753,11 +773,12 @@ Schedule-producing parameter functions declare input and output units:
 def tarif() -> PiecewisePolynomialParamValue: ...
 ```
 
-Every supported `look_up` or `piecewise_polynomial` call screens its domain argument
-against the declared input axis and yields the declared output unit.
+For every supported `look_up` or `piecewise_polynomial` call, TTSIM checks the unit of
+the input variable against the schedule's input unit and assigns the declared output
+unit to the result.
 
-Structured parameters may declare `unit=UNSET_UNIT` only when their result has no single
-unit and every unit-carrying field has its own annotation.
+A structured parameter may use `unit=UNSET_UNIT` only when the object as a whole has no
+single unit and every field that carries a quantity has its own annotation.
 
 ```python
 @dataclass(frozen=True)
@@ -777,38 +798,37 @@ class SatzMitAltersgrenzen:
 def satz_mit_altersgrenzen() -> SatzMitAltersgrenzen: ...
 ```
 
-When a policy function accesses an annotated scalar field, body checking uses the
-field's unit. If a YAML leaf path matches an annotated field path, validation compares
-the two declarations. Renamed or derived fields have no automatic source-path
-comparison.
+When a policy function reads an annotated scalar field, the body checker uses that
+field's unit. If a YAML leaf and an annotated field have the same path, validation
+compares their declarations. TTSIM cannot make this automatic comparison for fields that
+were renamed or derived from other fields.
 
 (gep-10-generated)=
 
 (gep-10-auto)=
 
-### Generated nodes and aggregations
+### Automatically generated nodes and aggregations
 
 #### Reference-period conversions
 
-A generated reference-period conversion changes only the period component of a unit. For
-example, converting a household amount from monthly to yearly changes
-`CURRENCY_PER_MONTH_PER_HH` to `CURRENCY_PER_YEAR_PER_HH`; currency, physical
-components, and grouping level remain unchanged.
+An automatic period conversion changes only the period in a unit. For example, changing
+a monthly household amount into an annual household amount converts
+`CURRENCY_PER_MONTH_PER_HH` to `CURRENCY_PER_YEAR_PER_HH`. The currency, physical unit,
+and group marker remain the same.
 
-Pint supplies the ordinary ratios used by the existing generated converters. These are
-conventions for linear flows. They do not establish that every statute uses the same
-day-count or partial-period rule, and they do not convert effective returns by
-compounding.
+Pint supplies the standard ratios already used by GETTSIM. These ratios apply to linear
+flows. They do not establish the correct legal day count, treatment of partial periods,
+or compounding rule for every policy.
 
-The treatment of daily and other legally sensitive period conventions is deferred to
-[GETTSIM #1205](https://github.com/ttsim-dev/gettsim/issues/1205). Until that work is
-completed:
+The treatment of legally sensitive daily and other period conventions is deferred to
+[GETTSIM #1205](https://github.com/ttsim-dev/gettsim/issues/1205). Until that issue is
+resolved:
 
-- generated conversions retain the factors currently used on `main`;
-- the checker establishes dimensional compatibility, not statutory day-count
-  correctness; and
-- a formula requiring a different convention uses an explicit policy function rather
-  than an automatic suffix conversion.
+- automatic conversions keep the factors used on `main`;
+- the checker confirms that the units are compatible, not that the statute uses the same
+  day-count convention; and
+- formulas requiring another convention use an explicit policy function rather than an
+  automatic suffix conversion.
 
 (gep-10-extensity)=
 
@@ -816,69 +836,72 @@ completed:
 
 #### Aggregations
 
-Generated aggregations derive their result unit from the source unit, aggregation type,
+An aggregation changes the level represented by a value, much like `egen` with a `by()`
+option in Stata. TTSIM derives the result unit from the source unit, aggregation type,
 and target level.
 
-| Aggregation            | Base                             | Result level                               |
-| ---------------------- | -------------------------------- | ------------------------------------------ |
-| `SUM` of a non-boolean | preserved                        | target group; bare at an individual target |
-| `MIN`, `MAX`, `MEAN`   | preserved                        | target group; bare at an individual target |
-| `COUNT`                | `DIMENSIONLESS`                  | target group; bare at an individual target |
-| `SUM` of a boolean     | `DIMENSIONLESS` count            | target group; bare at an individual target |
-| `ANY`, `ALL`           | truth-compatible `DIMENSIONLESS` | target group; bare at an individual target |
+| Aggregation            | Quantity being measured          | Level of the result                                 |
+| ---------------------- | -------------------------------- | --------------------------------------------------- |
+| `SUM` of a non-Boolean | same as the source               | target group; person-level for an individual target |
+| `MIN`, `MAX`, `MEAN`   | same as the source               | target group; person-level for an individual target |
+| `COUNT`                | `DIMENSIONLESS`                  | target group; person-level for an individual target |
+| `SUM` of a Boolean     | `DIMENSIONLESS` count            | target group; person-level for an individual target |
+| `ANY`, `ALL`           | truth-compatible `DIMENSIONLESS` | target group; person-level for an individual target |
 
-A mean is a statistic of the target group. It does **not** become a person-level value
-merely because a symbolic group total divided by a head count would cancel the grouping
-denominator. Thus the mean wealth of a household has a household result level. To create
-a person-level allocation or per-person amount, use an explicit group-total/head-count
-calculation or an aggregation whose declared target is the individual person.
+A group mean remains a statistic of that group. For example, mean household wealth is a
+household-level result, even though one could write a separate formula that divides
+household total wealth by the household head count. To create a person-level allocation
+or per-person amount, use an explicit total-over-head-count calculation or aggregate to
+an individual target.
 
-`MIN` and `MAX` likewise remain properties of the target group. The current unit system
-does not distinguish totals, means, and extrema beyond the aggregation rule that
-produced them; it only checks their base, period, and target level.
+The same applies to `MIN` and `MAX`: the minimum or maximum is a property of the target
+group. The current unit system records the quantity, period, and group level. It does
+not otherwise distinguish a total, mean, minimum, and maximum once produced.
 
-A hand-written aggregation declares its unit. That declaration MUST exactly match the
-unit derived from its source, aggregation type, and target level. An intentional policy
-reinterpretation uses a local cast or `verify_units=False`, both of which are reported.
+A hand-written aggregation declares its result unit. The declaration MUST equal the unit
+derived from the source, aggregation type, and target level. If a policy intentionally
+interprets the result differently, it must use a local cast or `verify_units=False`, and
+the report records that exception.
 
-`@agg_by_p_id_function` assigns each result to an individual person and therefore has no
-grouping-level denominator. A group identifier remains `DIMENSIONLESS` because nominal
-identifier domains are outside this GEP.
+`@agg_by_p_id_function` assigns results to individual people and therefore has no group
+denominator. Group identifiers themselves remain `DIMENSIONLESS`; checking whether two
+identifiers belong to the same domain is outside this GEP.
 
 (gep-10-relations)=
 
 #### Joins
 
-The body checker provides only a dimensional join guard. For a supported `join` call:
+A supported `join` receives checks similar to a limited review of a Stata `merge`:
 
-- modeled foreign and primary keys MUST carry no physical or period dimension;
-- the missing-key fallback MUST be unit-compatible with the target, except for the
-  documented dimensionless sentinel case; and
-- the result inherits the target unit.
+- the foreign and primary keys MUST have no physical unit or period;
+- the fallback used for a missing key MUST have a unit compatible with the target,
+  except for the documented dimensionless sentinel case; and
+- the joined result has the unit of the target variable.
 
-This check does **not** establish that the two keys have the same nominal domain, that
-the primary key is unique, that cardinality is correct, or that source and destination
-rows are aligned. Those properties remain the responsibility of the existing relation
-and runtime validation layers.
+These checks do not show that the two keys identify the same kind of entity, that the
+primary key is unique, that the merge has the intended cardinality, or that the source
+and destination rows are correct. Existing data and relation checks remain responsible
+for these properties.
 
-A join stand-in that ignores a key or fallback is nonconforming. If a future join option
-has unit-relevant behavior and no unit rule, the call must be rejected rather than
-silently returning the target unit.
+TTSIM's checking implementation of a join must inspect the keys and the fallback. If a
+new join option can affect units and TTSIM has no rule for it, the checker must reject
+the call rather than assume the target unit is unchanged.
 
-#### In-body reductions
+#### Reductions inside policy functions
 
-Raw array reductions such as `xnp.sum`, `xnp.amin`, and `xnp.amax` can change which rows
-or axes a result represents. The current unit checker has no static array-axis metadata
-from which to derive that change. It therefore MUST reject these operations during body
-checking instead of passing through the operand's unit.
+Array operations such as `xnp.sum`, `xnp.amin`, and `xnp.amax` may change what one row
+of the result represents. Unlike a declared aggregation, a raw reduction does not tell
+the checker which observations or array dimensions were combined. This is similar to
+seeing a Stata total without knowing the `by()` variables.
 
-A function requiring such a reduction must either:
+The checker therefore MUST reject these reductions inside a checked policy body instead
+of simply copying the unit of the input. A function that needs such a reduction must:
 
 - express it as a generated or hand-written aggregation with a declared target level; or
-- use `verify_units=False`, which is then reported as an unchecked body.
+- use `verify_units=False`, which the report then lists as an unchecked body.
 
-This conservative refusal closes a false-certification path; it is not a claim that all
-reductions are dimensionally invalid.
+The rejection does not mean that reductions are inherently wrong. It means that TTSIM
+lacks enough information to certify their result level.
 
 (gep-10-declarations)=
 
@@ -886,45 +909,45 @@ reductions are dimensionally invalid.
 
 #### Declaration matrix
 
-| Object                               | Declaration                           | Currency base                      | Validation                                               |
-| ------------------------------------ | ------------------------------------- | ---------------------------------- | -------------------------------------------------------- |
-| `@policy_function`                   | required `unit=`                      | `CURRENCY` for monetary values     | declaration, suffixes, and supported body paths          |
-| `@policy_input`                      | required `unit=`                      | `CURRENCY` for monetary values     | declaration and suffixes                                 |
-| scalar or dictionary parameter       | `unit:`                               | concrete currency where monetary   | schema, suffix, and statutory currency                   |
-| mapping parameter                    | `input_unit:` and `output_unit:`      | concrete currency where applicable | schema and axes                                          |
-| structured `@param_function`         | `unit=UNSET_UNIT`                     | units on fields                    | field use and matching parameter leaves                  |
-| schedule-producing `@param_function` | `InputOutputUnits(...)`               | abstract `CURRENCY` in code        | schedule call sites                                      |
-| generated time conversion            | automatic                             | inherited                          | target period from suffix                                |
-| generated aggregation                | automatic                             | inherited                          | aggregation rule and target level                        |
-| hand-written aggregation             | required `unit=`                      | abstract `CURRENCY` in code        | exact derived unit unless opted out                      |
-| group-creation function              | required or generated `DIMENSIONLESS` | not applicable                     | declaration only                                         |
-| rounding specification               | required for monetary magnitudes      | concrete currency                  | function unit and statutory currency                     |
-| unit-annotated input                 | required on every leaf in that mode   | concrete source currency           | token vocabulary, suffix period, and currency conversion |
+| Object                               | Required declaration                  | Currency                         | What TTSIM checks                                      |
+| ------------------------------------ | ------------------------------------- | -------------------------------- | ------------------------------------------------------ |
+| `@policy_function`                   | `unit=`                               | abstract `CURRENCY` for money    | declaration, suffixes, and supported cases in the body |
+| `@policy_input`                      | `unit=`                               | abstract `CURRENCY` for money    | declaration and suffixes                               |
+| scalar or dictionary parameter       | `unit:`                               | concrete currency for money      | schema, suffix, and statutory currency                 |
+| schedule or lookup parameter         | `input_unit:` and `output_unit:`      | concrete currency where relevant | schema and both units                                  |
+| structured `@param_function`         | `unit=UNSET_UNIT`                     | units on fields                  | field use and matching YAML leaves                     |
+| schedule-producing `@param_function` | `InputOutputUnits(...)`               | abstract `CURRENCY` in code      | schedule calls                                         |
+| generated period conversion          | automatic                             | inherited                        | target period from the suffix                          |
+| generated aggregation                | automatic                             | inherited                        | aggregation rule and target level                      |
+| hand-written aggregation             | `unit=`                               | abstract `CURRENCY` in code      | exact derived unit unless opted out                    |
+| group-creation function              | required or generated `DIMENSIONLESS` | not applicable                   | declaration only                                       |
+| rounding specification               | unit required for monetary magnitudes | concrete currency                | function unit and statutory currency                   |
+| unit-annotated input                 | unit on every leaf in this mode       | concrete source currency         | known unit, suffix period, and currency conversion     |
 
-Use `UNSET_UNIT` only for a structured producer with no single unit. For ordinary
-parameters, functions, and aggregations, a missing declaration is an error.
+`UNSET_UNIT` is only for a structured result that has no single unit. For ordinary
+parameters, functions, and aggregations, a missing unit declaration is an error.
 
 (gep-10-literals)=
 
-### Numerical literals
+### Numerical constants
 
-Multiplication and division by a bare numerical literal are valid and preserve or
-compose the other operand's unit.
+Multiplication and division by an ordinary numerical constant are valid. The constant
+keeps or combines with the other value's unit.
 
 ```python
 betrag_m * 0.5  # CURRENCY_PER_MONTH
 wealth * 0.8  # CURRENCY, not CURRENCY_PER_MONTH
 ```
 
-A non-zero bare literal cannot be added to, subtracted from, or ordered against a
-dimensioned quantity.
+A non-zero constant with no declared unit cannot be added to, subtracted from, or
+ordered against a quantity that has a unit.
 
 ```python
 einkommen_m < 1000.0  # Invalid: different units.
 ```
 
-A dimensioned threshold should normally be a parameter. If it must remain in the body, a
-local cast gives the literal its intended unit.
+A threshold with a unit should normally be stored as a policy parameter. If it must be
+written directly in the function, a local cast states its unit.
 
 ```python
 einkommen_m < cast_ttsim_unit(
@@ -933,8 +956,9 @@ einkommen_m < cast_ttsim_unit(
 )
 ```
 
-Zero is the sole polymorphic numerical-literal exception. It may act as an additive
-identity, return arm, or `min`/`max`/`clip` bound and adopts the compatible other unit.
+Zero is the only numerical constant that may adapt to another unit. It may serve as the
+neutral value in addition, as one result of a conditional, or as a bound in
+`min`/`max`/`clip`.
 
 ```python
 @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
@@ -942,23 +966,22 @@ def betrag_m(einkommen_m: float, befreit: bool) -> float:
     return 0.0 if befreit else einkommen_m
 ```
 
-A bare literal cannot acquire an identifier, category, or calendar-point meaning through
-this rule. Those distinctions are outside the unit system and remain subject to ordinary
-runtime typing and policy review.
+This zero rule does not give a constant the meaning of an identifier, category, or
+calendar point. Runtime typing and policy review remain responsible for those meanings.
 
 (gep-10-nullability)=
 
 ### Missing values and nullability
 
-Missingness is not a physical unit. This GEP does not replace GEP 9's runtime treatment
-of nullable values, sentinels, or backend-specific missing representations. During body
-linting, a missing-key fallback is checked only for dimensional compatibility with the
-join target. The unit checker does not prove that a numeric sentinel is valid for a
-particular identifier domain.
+Missingness is not a physical unit. This GEP does not replace the GEP-9 rules for
+nullable values, sentinel values, or backend-specific missing-value representations. For
+a join, the checker tests whether a missing-key fallback has a unit compatible with the
+joined value. It does not establish that a particular number is a valid missing code for
+an identifier.
 
-A `NaN`, `-1`, or other sentinel does not acquire semantic missing-value meaning from
-`DIMENSIONLESS`. Policy packages remain responsible for their ordinary runtime and data
-validation contracts.
+For example, `NaN` or `-1` does not gain a missing-value meaning merely because it is
+`DIMENSIONLESS`. Policy packages continue to define and validate their missing-value
+conventions.
 
 (gep-10-currency-type)=
 
@@ -966,11 +989,11 @@ validation contracts.
 
 ### Currency
 
-#### Registration and statutory currency
+#### Currency registry and statutory currency
 
-A policy package constructs one `UnitSystem` containing its supported currencies and
-statutory history. GETTSIM uses Euro as the base currency and defines Deutsche Mark by
-the official conversion factor.
+A policy package creates one `UnitSystem` with its supported currencies and the dates on
+which each currency is statutory. GETTSIM uses Euro as the base currency and defines
+Deutsche Mark with the official conversion factor.
 
 ```python
 UNIT_SYSTEM = UnitSystem(
@@ -984,41 +1007,41 @@ UNIT_SYSTEM = UnitSystem(
 )
 ```
 
-Exactly one currency is statutory at every supported policy date. That currency is the
-**only** denomination permitted inside the active policy computation.
+Exactly one currency is statutory on every supported policy date. All monetary
+calculations inside that policy regime use this currency.
 
-Environment assembly MUST verify that, for every checked regime:
+For every checked regime, environment assembly MUST verify that:
 
-- every active concrete monetary parameter uses the statutory currency;
-- every active monetary rounding specification uses the statutory currency;
-- every code-side `CURRENCY` declaration resolves to the statutory currency; and
-- no active producer introduces a second concrete currency into a policy-function body.
+- each active monetary parameter uses the statutory currency;
+- each active monetary rounding rule uses the statutory currency;
+- each Python declaration using `CURRENCY` resolves to the statutory currency; and
+- no input, parameter, or function introduces another currency into a policy
+  calculation.
 
-The single-currency invariant deliberately excludes simultaneous DM and EUR values from
-one policy regime. Retroactive or carried amounts that must retain a different legal
-denomination require a future extension and are not silently admitted by this GEP.
+This rule deliberately excludes calculations that keep DM and EUR amounts side by side
+inside one policy regime. A retroactive or carried amount that legally retains another
+currency needs a future extension; GEP 10 does not admit it silently.
 
-#### Parameters and data currencies
+#### Parameter currency and data currency
 
-Parameters are not converted. Validation instead requires their concrete currency to
-match the statutory currency of every regime in which they are active. This preserves
-statutory numerical values, including legally rounded values introduced at a currency
-changeover.
+GETTSIM does not convert policy parameters. Instead, it verifies that each parameter is
+written in the statutory currency for every regime in which it applies. This preserves
+the numerical values in the law, including values that were legally rounded when the
+currency changed.
 
-Input data may use a different concrete currency. Monetary inputs are converted to the
-statutory currency before policy evaluation. Computed monetary outputs are converted to
-`data_currency` only after statutory calculation and rounding.
+Input data may use another currency. Before calculating the policy, GETTSIM converts
+monetary inputs into the statutory currency. It converts calculated monetary outputs to
+`data_currency` only after applying the policy formula and statutory rounding.
 
-An annotated input may therefore contain DM values for a Euro policy run or Euro values
-for a DM policy run. The boundary performs the conversion before the values enter the
-DAG. Mixed source currencies across separately annotated input leaves are acceptable
-only because each leaf is converted to the one statutory currency before policy
-computation.
+Tagged input columns may therefore contain DM for a Euro policy date or Euro for a DM
+policy date. Different tagged input columns may even state different source currencies,
+because each is converted separately into the one statutory currency before entering the
+policy calculation.
 
 #### Currency changes in parameter histories
 
-A dated parameter entry inherits the most recent earlier unit declaration. A new unit
-declaration applies from its date onward.
+A dated parameter entry inherits the latest earlier unit declaration. A new declaration
+applies from its own date onward.
 
 ```yaml
 arbeitnehmerpauschbetrag_y:
@@ -1033,34 +1056,34 @@ arbeitnehmerpauschbetrag_y:
     value: 1000
 ```
 
-Resolution uses only declarations at or before the policy date. A statutory-currency
-transition opens a new validation regime even when no function starts or ends on that
-date.
+Only declarations on or before the policy date are used. A change in statutory currency
+starts a new validation regime even when the set of active policy functions does not
+change.
 
-#### Coefficients whose numerical meaning depends on currency
+#### Currency-dependent coefficients
 
-Some statutory formulas contain coefficients whose mathematical units include inverse
-currency, even when the statute prints them as bare numbers. The present compositional
-vocabulary does not attempt to encode arbitrary inverse-currency powers for all
-structured coefficients.
+Some legal formulas contain coefficients whose numerical values depend on the currency
+used in the formula. Although the law may print these coefficients as plain numbers,
+their mathematical units can include inverse powers of currency. The unit vocabulary in
+this GEP does not represent every such coefficient.
 
-The adopted first-stage rule is therefore:
+The first-stage rule is therefore:
 
-- evaluate the complete formula in the one statutory currency of the regime;
-- retain the statutory coefficient values exactly as written; and
-- do not claim that the unit checker has proved the dimensional semantics of
-  coefficients represented as bare values.
+- evaluate the entire formula in the statutory currency of the regime;
+- keep the statutory coefficient values exactly as written; and
+- do not claim that the unit checker verified the full unit meaning of coefficients
+  stored as plain values.
 
-Such formulas may require a local cast or body opt-out and appear as such in the
-validation report. Statutory-currency evaluation preserves their numerical convention;
-it is not a substitute for full coefficient-unit verification.
+These formulas may need a local cast or a body opt-out, which is visible in the report.
+Using the statutory currency preserves the formula's numerical convention, but it does
+not amount to a unit proof of every coefficient.
 
 (gep-10-rounding)=
 
 #### Rounding specifications
 
-A monetary rounding specification declares the concrete currency and complete unit of
-its numerical magnitudes.
+A monetary rounding rule declares the concrete currency and full unit of its numerical
+amounts.
 
 ```python
 @policy_function(
@@ -1078,10 +1101,10 @@ its numerical magnitudes.
 def zu_versteuerndes_einkommen_y_sn(): ...
 ```
 
-The rounding unit must equal the function unit after resolving `CURRENCY` to the
-statutory currency. A function active across a statutory-currency change must be split
-or receive date-appropriate rounding specifications. Presentation-currency conversion
-occurs after rounding.
+After `CURRENCY` is replaced by the statutory currency, the rounding unit must equal the
+function unit. A function that spans a currency change must be split or use rounding
+rules appropriate to each date. Conversion into the user's output currency happens after
+rounding.
 
 (gep-10-validation)=
 
@@ -1089,93 +1112,92 @@ occurs after rounding.
 
 ### Validation and limitations
 
-#### Validation stages
+#### When checks take place
 
-| Stage                         | When                            | Input                                  | Validates                                                                            |
-| ----------------------------- | ------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------ |
-| declaration validation        | decoration or parameter loading | declarations                           | required fields, grammar, suffixes, and allowed currency bases                       |
-| environment validation        | policy-environment assembly     | graph declarations and generated rules | required units, aggregation derivations, statutory currency, and regime completeness |
-| function-body linting         | policy-environment assembly     | unit-carrying placeholders             | supported operations and explored returns                                            |
-| annotated-input boundary      | input canonicalisation          | user tags and column names             | known tokens, exact suffix period, and source-currency conversion                    |
-| numerical boundary conversion | before and after computation    | values and conversion factor           | input to statutory currency; computed results to data currency                       |
+| Stage                         | When                                                  | What is checked                                                                                |
+| ----------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| declaration validation        | when a function is decorated or parameters are loaded | required declarations, valid unit names, suffixes, and permitted currencies                    |
+| environment validation        | when a policy environment is assembled                | all required units, generated aggregation units, statutory currency, and complete date regimes |
+| policy-body checking          | when a policy environment is assembled                | supported calculations and every examined return case                                          |
+| tagged-input boundary         | when user input is prepared                           | known unit names, exact period suffixes, and source-currency conversion                        |
+| numerical currency conversion | immediately before and after policy calculation       | input into statutory currency and calculated output into data currency                         |
 
-Pint quantities are used while declarations and policy environments are checked, while
-annotated input is processed, and while numerical conversion factors are derived. Pint
-quantities do not enter the compiled tax-and-transfer function or a JAX trace.
+TTSIM uses Pint quantities while it checks declarations and policy environments,
+processes tagged input, and obtains currency conversion factors. The compiled tax and
+transfer calculation and JAX traces continue to use ordinary numerical arrays.
 
 (gep-10-body-checker)=
 
-#### Function-body linting
+#### Checking policy-function calculations
 
-TTSIM evaluates a policy-function body with placeholders carrying the declared units of
-its arguments. Conditional branches are explored by re-evaluating the body with
-different branch decisions. Each explored return path is checked separately.
+TTSIM calls a policy function with test values that carry the declared units of its
+arguments. It repeats the call with different decisions to examine the relevant branches
+of `if` statements and conditional expressions. Each examined return value is compared
+with the function's declaration.
 
-The body checker is a linter over a documented operation set. It is conforming only when
-every supported stand-in inspects every operand that can affect the result's unit.
-Scalar and vectorized spellings of the same operation MUST use equivalent rules.
+TTSIM knows unit rules for a defined set of operations. For each supported operation,
+its checking version MUST inspect every argument that can affect the resulting unit.
+Scalar and vectorized versions of the same calculation MUST follow equivalent rules.
 
-Body linting rejects, among other things:
+The checker rejects, among other things:
 
-- addition, subtraction, or ordering of unit-incompatible quantities;
-- a non-zero bare literal used as a dimensioned value;
-- a return unit that differs from the declaration in physical dimension, period, or
-  grouping level;
-- a value with physical or period content used in a truth context;
-- an `xnp.where` condition with physical or period content;
-- unsupported in-body reductions;
-- a supported join with a physically dimensioned key or incompatible fallback;
-- an untyped numerical value accessed from a structured parameter;
-- inconsistent schedule input and output axes; and
-- any operation for which no faithful unit stand-in exists, unless the function
-  explicitly opts out.
+- addition, subtraction, or ordering between incompatible units;
+- a non-zero constant used as if it had a physical unit;
+- a return value with the wrong physical unit, period, or group level;
+- an amount, duration, or rate with a period used as a yes/no condition;
+- an invalid condition in `xnp.where`;
+- an array reduction whose target level cannot be determined;
+- a join with a key carrying a physical unit or a fallback with the wrong unit;
+- a numerical field from a structured parameter that lacks a unit;
+- a schedule called with the wrong input unit or assigned the wrong output unit; and
+- an operation for which TTSIM has no faithful unit rule, unless the function explicitly
+  opts out.
 
-The checker MUST NOT silently preserve the input unit when an operation changes a
-unit-relevant axis or grouping interpretation. A stand-in that discards `axis`,
-`condition`, `foreign_key`, `primary_key`, `fallback`, or another unit-relevant argument
-is nonconforming.
+The checker MUST NOT assume that the old unit survives an operation that may change a
+physical dimension, period, or group interpretation. In particular, it may not ignore an
+array dimension, condition, merge key, fallback, or another argument relevant to units.
 
-Branch exploration is bounded. Environment assembly fails when a body exceeds the
-implementation's documented path or decision limit; the author must simplify it or use a
-reported opt-out.
+The number of branches that TTSIM can examine is limited. If a function exceeds the
+documented limit on paths or decisions, environment assembly fails. The author must
+simplify the function or use a reported opt-out.
 
 (gep-10-date-partition)=
 
 (gep-10-policy-dates)=
 
-#### Exhaustive policy-date regimes
+#### Checking all relevant policy dates
 
-A policy package is not validated exhaustively by testing function start dates alone.
-TTSIM constructs a half-open date partition from every boundary that can change the
-resolved unit environment.
+Checking only the start dates of policy functions is not enough. A parameter, rounding
+rule, or statutory currency may change while the active functions remain the same. TTSIM
+therefore divides the supported date range into intervals within which the unit
+environment is constant.
 
-The partition MUST include:
+A new interval MUST begin at:
 
 - every function start date;
 - the day after every inclusive function end date;
-- every dated parameter entry, including entries that change only a value, unit, leaf
-  set, or currency;
-- every statutory-currency transition; and
-- every separately dated rounding-rule boundary not already represented by a function
-  boundary.
+- every dated parameter entry, including a change only to its value, unit, set of
+  leaves, or currency;
+- every change of statutory currency; and
+- every separate rounding-rule date not already represented by a function boundary.
 
-Boundaries are clipped to the policy package's supported date domain. At least one
-representative date, normally the left endpoint, is assembled and checked for every
-resulting interval.
+TTSIM limits these boundaries to the dates supported by the policy package. It assembles
+and checks at least one representative date—normally the first date—in every resulting
+interval.
 
-`ttsim.testing_utils.get_policy_date_partition` provides the reusable implementation for
-TTSIM policy packages. A parameter-only or currency-only change must open a regime even
-if the active function set is unchanged.
+`ttsim.testing_utils.get_policy_date_partition` provides this date partition for TTSIM
+policy packages. A parameter-only or currency-only change must start a new interval even
+when no policy function changes.
 
 (gep-10-evidence)=
 
 (gep-10-coverage)=
 
-#### Validation reporting
+#### Validation report
 
-Every environment check MUST expose a summary that distinguishes declaration coverage
-from body coverage. The exact class and field names are implementation details, but the
-report contains at least:
+Every environment check MUST separate the coverage of declarations from the coverage of
+function bodies. Field names may differ across implementations, but the report contains
+at least:
 
 ```text
 resolved declarations
@@ -1187,15 +1209,15 @@ bodies rejected as unsupported
 policy-date regimes checked
 ```
 
-Counts alone are insufficient for exceptions. The report also lists the function or node
-names using `cast_ttsim_unit` or `verify_units=False`.
+A count is not enough for an exception. The report also names every function or node
+that uses `cast_ttsim_unit` or `verify_units=False`.
 
-A project may say that all required declarations are present while still containing
-unchecked bodies. It may say that all non-exempt supported bodies passed the unit
-linter. It MUST NOT describe an opted-out body as verified, and it MUST NOT use “100%
-annotated” as a synonym for “100% body checked.”
+A project may correctly report that every required declaration is present even when some
+bodies are unchecked. It may report that every supported, non-exempt body passed the
+unit checker. It MUST NOT call an opted-out body verified, and “100% annotated” MUST NOT
+be used as another name for “100% of bodies checked.”
 
-A suitable CI summary is, for example:
+For example, CI might report:
 
 ```text
 Declarations resolved: 412 / 412
@@ -1209,62 +1231,63 @@ Date regimes:             37
 
 (gep-10-failures)=
 
-#### Failure diagnostics
+#### Error messages
 
-A dimensional failure SHOULD identify the policy node, policy date or regime, source
-expression, expected unit, inferred unit, and the operation that failed. A branch or
-`xnp.where` failure SHOULD identify the condition or incompatible arm. A join failure
-SHOULD identify whether a key or fallback caused it. An unsupported reduction SHOULD
-name the reduction and explain that row or axis metadata is unavailable.
+A unit error SHOULD identify the policy node, date or date interval, source expression,
+expected unit, inferred unit, and failing operation. An error in a conditional or
+`xnp.where` SHOULD identify the condition or the two incompatible results. A join error
+SHOULD say whether a key or fallback caused it. An unsupported reduction SHOULD name the
+operation and explain that the checker lacks information about its rows or axes.
 
-Diagnostics must not recommend a generic cast as the default repair. They may state that
-a local cast or body opt-out is available, while making clear that either is an
-assertion or loss of body coverage.
+An error message should not present a cast as the standard repair. It may mention a
+local cast or body opt-out, but it must explain that the former is an assertion and the
+latter removes body coverage.
 
 (gep-10-limitations)=
 
 #### Trade-offs and limitations
 
-**Dimensionless semantics are mostly unchecked.** `DIMENSIONLESS` covers shares, IDs,
-categories, bare rates, and ordinary scalars. The unit system cannot generally reject
-arithmetic between them. Truth compatibility excludes dimensioned values but does not by
-itself prove that a dimensionless selector is a Boolean.
+**Different dimensionless meanings are usually not checked.** Shares, identifiers,
+categories, rates without a period, and ordinary scalars all use `DIMENSIONLESS`. TTSIM
+cannot generally reject calculations between them. The condition rule excludes values
+with physical units or periods, but it does not by itself prove that a dimensionless
+value is a Boolean.
 
-**Equality is unchecked.** Equality operators do not compare units. This permits
-sentinel comparisons such as `p_id_empfänger == -1`, but also means equality between
-monthly and yearly income is not detected.
+**Equality does not compare units.** This permits useful sentinel comparisons such as
+`p_id_empfänger == -1`. It also means that the checker does not catch an equality
+comparison between monthly and annual income.
 
-**Grouping markers are not relational grain.** They do not prove row alignment,
-uniqueness, cardinality, broadcast provenance, or the nominal domain of an ID. A bare
-household-specific share remains bare because this GEP does not model where it is
-stored.
+**Group markers do not validate the data layout.** They do not prove that rows are
+aligned, keys are unique, a merge has the right number of matches, or an identifier
+belongs to a particular domain. A household-specific share remains bare because this GEP
+records its unit, not where it is stored in the dataset.
 
-**The group algebra is intentionally partial.** Only documented head-count conversions,
-scalar modification, logical rules, and generated aggregations are checked. Other
-products or ratios involving group-marked quantities require an explicit assertion or
+**Only selected group calculations are supported.** TTSIM checks the head-count
+conversions, scalar changes, logical rules, and generated aggregations stated above.
+Other products or ratios involving group-marked values need a local assertion or an
 opt-out.
 
-**Body exploration is bounded.** Code outside the explored paths or beyond the path
-limit is not silently certified.
+**Branch checking has a limit.** A body that exceeds the path or decision limit is not
+silently accepted.
 
-**Some operations are unsupported.** In-body array reductions are rejected. Joins
-receive only the dimensional checks documented above. Nominal domains and cardinality
-are not proved.
+**Some operations remain unsupported.** Raw array reductions are rejected. Joins receive
+only the unit checks described above; they do not show that the keys identify the same
+kind of entity or that the merge produces the intended number of matches.
 
-**Annotated-input validation is partial.** It checks known tokens, exact suffix periods,
-and currency conversion. It does not compare every tag's physical dimension or grouping
-level with the target node declaration.
+**Tagged-input validation is partial.** It checks valid unit names, exact period
+suffixes, and currency conversion. It does not compare every physical or group component
+of the tag with the declaration of the target node.
 
-**Automatic period ratios are conventions.** Their dimensional validity does not prove a
-statute-specific day-count, partial-period, or compounding rule. See
-[GETTSIM #1205](https://github.com/ttsim-dev/gettsim/issues/1205).
+**Automatic period ratios are conventions.** A valid conversion of units does not prove
+that the ratio follows a policy's legal day-count, partial-period, or compounding rule.
+See [GETTSIM #1205](https://github.com/ttsim-dev/gettsim/issues/1205).
 
-**Currency provenance is regime-level.** The model assumes one statutory currency per
-policy regime and does not support simultaneous monetary values that retain distinct
-historical legal denominations inside one body.
+**Currency is recorded at the regime level.** Each regime has one statutory currency.
+The model does not yet support values in different historical legal currencies inside
+one policy-function body.
 
-**A cast is an assertion.** An incorrect cast can hide an error. Casts are reported and
-must remain local.
+**A cast is an assertion.** If the author states the wrong unit in a cast, the cast can
+hide an error. Casts must remain local and appear in the validation report.
 
 (gep-10-exceptions)=
 
@@ -1272,166 +1295,167 @@ must remain local.
 
 #### Explicit exceptions
 
-`cast_ttsim_unit(value, unit=unit)` replaces the inferred unit of one expression during
-body linting. At numerical execution, it returns `value` unchanged.
+`cast_ttsim_unit(value, unit=unit)` tells the body checker to treat one expression as
+having the stated unit. During the actual numerical calculation, it returns `value`
+unchanged.
 
-It is appropriate for:
+A cast is appropriate for:
 
-- a policy-defined transfer between grouping concepts that the generic group algebra
-  cannot derive;
-- a dimensioned implementation constant that is not a statutory parameter; or
-- a narrow formula seam involving a known coefficient or operation outside the current
-  vocabulary.
+- a policy-defined transfer between group concepts that the standard group rules cannot
+  derive;
+- a constant with a unit that is part of the implementation rather than a statutory
+  parameter; or
+- a small part of a formula involving a known coefficient or operation outside the
+  current vocabulary.
 
-It should apply to the smallest expression requiring the assertion. Every cast is listed
-in the validation report.
+The cast should cover the smallest possible expression. Every cast is named in the
+validation report.
 
-`verify_units=False` disables body linting for one decorated function or hand-written
-aggregation. Its declared output unit remains the contract used by consumers. It is
-appropriate only when the body:
+`verify_units=False` disables body checking for one decorated function or hand-written
+aggregation. The declared output unit still tells downstream functions what the result
+represents. An opt-out is appropriate only when the body:
 
 - uses an unsupported operation;
-- exceeds the branch-exploration limit; or
-- implements a policy interpretation that cannot be represented by the documented unit
-  rules.
+- exceeds the branch-checking limit; or
+- implements a policy interpretation that the documented unit rules cannot express.
 
-Every opt-out is listed separately and does not increase checked-body coverage. A policy
-package with opt-outs may be declaration-complete and may pass environment assembly; it
-must not claim that every body was unit checked.
+Every opt-out is listed separately and does not count toward checked-body coverage. A
+policy package with opt-outs may have complete declarations and may assemble
+successfully, but it must not claim that every body was checked.
 
 (gep-10-conformance)=
 
 ## Conformance and acceptance requirements
 
-An implementation conforms to this GEP only if it satisfies all of the following:
+An implementation conforms to this GEP only if all of the following hold:
 
-1. every required object has a valid declaration under the compositional vocabulary;
-1. group-level dimensionless declarations are restricted to known counts and indicators;
-1. the restricted group algebra rejects unsupported products, ratios, and cross-level
-   operations;
-1. `MEAN`, `MIN`, and `MAX` derive the target group level;
-1. scalar truth contexts and `xnp.where` reject values with physical or period content;
-1. supported joins inspect keys and fallbacks, while unsupported join semantics are
-   documented rather than implied;
-1. raw in-body reductions fail when their result level cannot be derived;
-1. the policy-date partition includes function, parameter, rounding, and statutory-
-   currency boundaries as applicable;
-1. one statutory currency is enforced throughout each policy regime; and
-1. validation output distinguishes declarations, checked bodies, generated rules, casts,
-   and whole-body opt-outs.
+1. every object that requires a unit has a valid declaration;
+1. a group marker on a dimensionless value is limited to a known count or indicator;
+1. unsupported products, ratios, and calculations across group levels are rejected;
+1. `MEAN`, `MIN`, and `MAX` produce a result at the target group level;
+1. scalar conditions and `xnp.where` reject values with physical units or periods;
+1. supported joins inspect both keys and fallbacks, and do not imply that unchecked
+   merge properties were validated;
+1. a raw reduction fails when TTSIM cannot determine the level of its result;
+1. the checked date intervals include all relevant function, parameter, rounding, and
+   statutory-currency boundaries;
+1. every policy regime uses exactly one statutory currency; and
+1. validation output reports declarations, checked bodies, generated rules, casts, and
+   whole-body opt-outs separately.
 
-Green project tests without these cases are not sufficient evidence of conformance. The
-implementation test suite SHOULD include adversarial mutations for each rule, including
-stock-versus-flow returns, dimensioned truth conditions, vectorized conditions, wrong
-join fallbacks, group-level shares, group means, parameter-only dates, and currency-only
-dates.
+Passing the ordinary project tests is not enough to demonstrate these requirements. The
+implementation tests SHOULD deliberately introduce a mistake for every rule. Examples
+include returning a stock where a flow is declared, using money as a condition, passing
+an invalid condition to `xnp.where`, using a fallback with the wrong unit in a join,
+marking a share as a group total, treating a group mean as person-level, and omitting a
+date on which only a parameter or currency changes.
 
 ## Related work
 
-- {ref}`GEP 1 <gep-1>` defines the time and grouping suffixes validated here.
+- {ref}`GEP 1 <gep-1>` defines the period and group suffixes checked here.
 - {ref}`GEP 2 <gep-2>` defines `*_id` columns and group creation.
-- {ref}`GEP 4 <gep-4>` defines the DAG, aggregations, and generated reference-period
-  conversions.
+- {ref}`GEP 4 <gep-4>` defines the DAG, aggregations, and generated period conversions.
 - {ref}`GEP 5 <gep-5>` defines rounding specifications.
-- {ref}`GEP 9 <gep-9>` defines runtime type validation and the user/canonical data
-  split.
-- [Pint](https://pint.readthedocs.io) supplies the physical-unit registry and algebra.
+- {ref}`GEP 9 <gep-9>` defines runtime type checking and the conversion from user data
+  to the standard internal data format.
+- [Pint](https://pint.readthedocs.io) supplies the physical-unit registry and ordinary
+  unit arithmetic.
 - [GETTSIM #1205](https://github.com/ttsim-dev/gettsim/issues/1205) tracks legally
   sensitive reference-period conventions.
 - [GETTSIM #1219](https://github.com/ttsim-dev/gettsim/issues/1219) records the review
-  that led to the narrowed guarantee and additional guards in this revision.
+  that led to the narrower guarantee and additional safeguards in this revision.
 
 ## Implementation
 
-The implementation is divided between TTSIM infrastructure and policy-system
-annotations.
+The implementation is split between TTSIM infrastructure and the unit declarations in
+each policy system.
 
 - TTSIM [#138](https://github.com/ttsim-dev/ttsim/pull/138) contains the unit registry,
-  compositional vocabulary, declarations, generated aggregation rules, body linter, and
-  input-boundary machinery.
-- TTSIM [#141](https://github.com/ttsim-dev/ttsim/pull/141) annotates the bundled
-  fictional METTSIM policy system.
-- TTSIM [#150](https://github.com/ttsim-dev/ttsim/pull/150) tightens truth contexts,
-  `xnp.where`, join operands, unsupported reductions, the stock/flow reproducer, and the
-  policy-date partition.
+  vocabulary, declarations, generated aggregation rules, body checker, and input
+  boundary.
+- TTSIM [#141](https://github.com/ttsim-dev/ttsim/pull/141) adds units to the fictional
+  METTSIM policy system.
+- TTSIM [#150](https://github.com/ttsim-dev/ttsim/pull/150) strengthens the checks for
+  conditions, `xnp.where`, joins, reductions, stocks and flows, and policy-date
+  intervals.
 - GETTSIM [#1193](https://github.com/ttsim-dev/gettsim/pull/1193) contains GEP 10.
-- GETTSIM [#1212](https://github.com/ttsim-dev/gettsim/pull/1212) contains the GETTSIM
-  rollout.
+- GETTSIM [#1212](https://github.com/ttsim-dev/gettsim/pull/1212) adds the declarations
+  to GETTSIM.
 
-Before this GEP is described as implemented, the code and test suite must additionally
-cover the normative changes introduced by this revision:
+Before this GEP is described as implemented, the code and tests must also cover the
+requirements added by this revision:
 
-- prohibit group-level dimensionless shares and rates while retaining documented group
-  counts and indicators;
-- restrict generic products and ratios of group-marked quantities;
-- derive `MEAN` at the target group rather than automatically making it bare;
+- reject group-level shares and rates while retaining the documented group counts and
+  indicators;
+- restrict general products and ratios between group-marked quantities;
+- keep `MEAN` at the target group level rather than treating it as person-level;
 - report casts and whole-body opt-outs separately from checked bodies; and
-- align public calendar wording with the ordinal semantics specified here.
+- use the calendar-year and ordinal meanings stated here in the public documentation.
 
 (gep-10-alternatives)=
 
 ## Alternatives
 
-### A general multi-axis value-type system
+### A broader system for units, data levels, and economic meaning
 
-Deferred. A broader design could represent physical unit, semantic kind, row index,
-nominal key domain, extensity, tensor axes, calendar semantics, currency provenance, and
-nullability as independent type axes. Such a system could validate joins, row alignment,
-group-specific shares, inverse-unit coefficients, and more of the Python expression
-language.
+Deferred. A broader design could separately record the physical unit, economic meaning,
+observation level, kind of identifier, whether a value is a total or intensive measure,
+array dimensions, calendar meaning, currency history, and missing-value rules. It could
+then check more merge operations, row alignment, group-specific shares, and coefficients
+with inverse units.
 
-That design is substantially larger than the dimensional guards needed for the current
-GETTSIM and METTSIM rollout. This GEP instead states the limits of the Pint-centered
-model and fails closed where a supported operation would otherwise be falsely certified.
-A later GEP may add relational or semantic typing without changing the physical-unit
-rules here.
+Such a system would be much larger than the unit checks needed for the current GETTSIM
+and METTSIM rollout. This GEP therefore focuses on physical units, periods, and selected
+group calculations. It rejects an operation when accepting it would give a misleading
+impression of coverage. A later GEP may add checks of data relations or economic meaning
+without changing the physical-unit rules here.
 
-### A dedicated public `SHARE` or identifier unit
+### A separate public unit for shares or identifiers
 
-Deferred. Pint would still treat a share as physically dimensionless, so meaningful
-semantic restrictions would require a separate rule system. The present GEP prefers
-fewer public unit kinds and explicitly documents the dimensionless blind spot. It adds
-only the truth and group-declaration guards needed for the claims made here.
+Deferred. Pint correctly treats shares and identifiers as having no physical unit. A
+useful distinction between them would therefore require additional rules beyond Pint.
+This GEP keeps the public unit vocabulary small, documents what remains unchecked, and
+adds only the condition and group-declaration rules needed for its stated guarantees.
 
-### A complete relational grain model
+### A complete model of the dataset's observation level
 
-Deferred. Grouping levels in this GEP are restricted arithmetic markers, not row-domain
-types. Nominal ID domains, uniqueness, join cardinality, broadcast provenance, and
-alignment remain outside scope. Unsupported reductions fail rather than pretending that
-their row grain is unchanged.
+Deferred. The group markers in this GEP support selected arithmetic; they are not types
+for rows or merge keys. The kind and uniqueness of identifiers, the number of merge
+matches, broadcasting, and row alignment remain outside scope. A reduction that would
+require such information is rejected instead of being assigned an unchanged unit.
 
-### A person level, implied or spelled
+### An explicit person-level unit
 
-Rejected for this proposal. Earlier variants represented every person amount as
-`... / [person]` and head counts as `[person] / [group]`. This distinguished a bare rate
-or share from a per-person amount, but introduced an implied level on almost every value
-and two spellings for the same practical person quantity.
+Rejected for this proposal. Earlier designs wrote every person amount as
+`... / [person]` and every group head count as `[person] / [group]`. This made the
+person level explicit but added a component to almost every declaration and allowed two
+ways to write the same practical person quantity.
 
-The adopted model keeps person quantities bare and uses group head counts as
-`1 / [group]`. The consequence is explicit: after total/head-count division, the unit
-checker knows that the result is bare but does not maintain a separate person-grain
-type.
+The adopted design leaves person quantities without a group denominator and writes a
+group head count as `1 / [group]`. After dividing a group total by its head count, TTSIM
+knows that the result no longer carries the group marker. It does not separately record
+that the result is stored at the person level.
 
-### Convert every parameter to a selected run currency
+### Convert every parameter into the selected data currency
 
-Rejected. Some statutory formulas contain coefficients whose numerical values depend on
-the currency convention. Converting only the obvious monetary quantities could change
-the formula. The adopted design evaluates each regime entirely in its statutory
-currency, retains parameter and coefficient values as written, and converts only input
-and computed output at the boundary.
+Rejected. In some legal formulas, coefficient values depend on the currency in which the
+formula is evaluated. Converting only the obvious monetary inputs could change the
+formula. The adopted design calculates each regime entirely in its statutory currency,
+keeps parameter and coefficient values as written, and converts only input and
+calculated output at the boundary.
 
-### Pass Pint quantities through the DAG
+### Pass Pint quantities through the calculation DAG
 
-Rejected. `pint.Quantity` is not part of the intended NumPy/JAX numerical
-representation. Units are static properties checked during environment assembly and at
-interface boundaries. The compiled tax-and-transfer function continues to receive
-ordinary numeric values.
+Rejected. `pint.Quantity` is not part of the intended NumPy/JAX numerical data. Units
+are checked while a policy environment is assembled and at its input and output
+boundaries. The compiled tax and transfer function continues to receive ordinary numbers
+and arrays.
 
-### Remove concrete currency labels from parameters
+### Remove concrete currencies from parameter declarations
 
-Rejected. The one-currency-per-regime invariant would make these labels theoretically
-redundant, but they are useful validation checks and documentation. A parameter declared
-in Euro during a Deutsche-Mark regime should fail loudly.
+Rejected. Because each regime uses one statutory currency, concrete labels may appear
+redundant. They are nevertheless valuable checks and documentation. A Euro parameter
+used in a Deutsche-Mark regime should produce an immediate error.
 
 ## Discussion
 

--- a/docs/geps/gep-10.md
+++ b/docs/geps/gep-10.md
@@ -88,6 +88,9 @@ Python library for calculations with units, and covers:
 - unit declarations for policy functions, inputs, parameters, schedules, structured
   values, automatically generated calculations, aggregations, rounding rules, and
   optionally unit-annotated input data;
+- narrow count/indicator evidence attached to the exact scalar, mapping leaf, raw or
+  converted schedule axis, schedule output, or structured-field occurrence that it
+  authorizes;
 - checking the supported expressions inside policy functions;
 - explicit rules for conditions, `xnp.where` (an array-valued if-then-else), joins
   (merges), and reductions such as sums over arrays;
@@ -365,6 +368,10 @@ regime.
 - `DIMENSIONLESS` continues to cover shares, rates without a period, identifiers,
   categories, and other physically dimensionless numbers. This GEP does not add a
   separate public unit category for every economic meaning.
+- `QuantityKind` is narrow supporting information, not another unit. It is used only to
+  distinguish a known count or yes/no indicator from another dimensionless value where a
+  group marker is declared. For a multi-axis schedule, any non-generic kind is stated
+  separately for each axis.
 - `verify_units=False` may exclude one function body from checking, but the report lists
   it as unchecked. It MUST NOT count as a checked body.
 - `cast_ttsim_unit` remains available for a local unit assertion. The report lists each
@@ -405,26 +412,27 @@ regime.
 
 ### Terminology
 
-| Term               | Meaning                                                                                                                                             |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| quantity           | A value with a unit, such as income, age, a share, or a head count.                                                                                 |
-| base               | What is measured in the numerator, such as `CURRENCY`, `DIMENSIONLESS`, or `YEARS`.                                                                 |
-| period             | A denominator such as `MONTH` or `YEAR` that identifies a flow or rate.                                                                             |
-| grain              | The level at which a variable is defined or varies, such as person, household, or Bedarfsgemeinschaft.                                              |
-| group marker       | A denominator such as `HH` or `BG` that checks selected amounts, counts, or indicators at that grain. It is not a complete representation of grain. |
-| stock              | A quantity without a period denominator, such as wealth.                                                                                            |
-| flow               | A quantity with a period denominator, such as monthly income.                                                                                       |
-| rate               | A multiplier. A rate that converts a stock to a flow has a period denominator.                                                                      |
-| calendar point     | A location on a calendar, such as the year 2025.                                                                                                    |
-| calendar ordinal   | A position within a larger calendar unit, such as month 2 or day 15.                                                                                |
-| calendar duration  | A length of time, such as 18 years or 3 months.                                                                                                     |
-| statutory currency | The currency in which the law states the active parameters and rounding rules.                                                                      |
-| data currency      | The currency assumed for untagged input and requested for calculated output.                                                                        |
-| policy environment | The functions, inputs, parameters, and automatically generated calculations that apply on one policy date.                                          |
-| leaf               | A final value in a nested input or parameter structure, rather than a dictionary containing further entries.                                        |
-| body check         | Running supported policy formulas with unit-carrying test values and comparing the result with the declared unit.                                   |
-| cast               | A local assertion that tells the checker to use a stated unit for one expression.                                                                   |
-| opt-out            | `verify_units=False` on one function. Its output declaration still applies, but its calculations are not checked.                                   |
+| Term               | Meaning                                                                                                                                                                                                                          |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| quantity           | A value with a unit, such as income, age, a share, or a head count.                                                                                                                                                              |
+| base               | What is measured in the numerator, such as `CURRENCY`, `DIMENSIONLESS`, or `YEARS`.                                                                                                                                              |
+| period             | A denominator such as `MONTH` or `YEAR` that identifies a flow or rate.                                                                                                                                                          |
+| grain              | The level at which a variable is defined or varies, such as person, household, or Bedarfsgemeinschaft.                                                                                                                           |
+| group marker       | A denominator such as `HH` or `BG` that checks selected amounts, counts, or indicators at that grain. It is not a complete representation of grain.                                                                              |
+| quantity kind      | Narrow supporting information—`GENERIC`, `COUNT`, or `INDICATOR`—used only when deciding whether a dimensionless value may carry a group marker. It belongs to one exact declared value or schedule axis and is not a Pint unit. |
+| stock              | A quantity without a period denominator, such as wealth.                                                                                                                                                                         |
+| flow               | A quantity with a period denominator, such as monthly income.                                                                                                                                                                    |
+| rate               | A multiplier. A rate that converts a stock to a flow has a period denominator.                                                                                                                                                   |
+| calendar point     | A location on a calendar, such as the year 2025.                                                                                                                                                                                 |
+| calendar ordinal   | A position within a larger calendar unit, such as month 2 or day 15.                                                                                                                                                             |
+| calendar duration  | A length of time, such as 18 years or 3 months.                                                                                                                                                                                  |
+| statutory currency | The currency in which the law states the active parameters and rounding rules.                                                                                                                                                   |
+| data currency      | The currency assumed for untagged input and requested for calculated output.                                                                                                                                                     |
+| policy environment | The functions, inputs, parameters, and automatically generated calculations that apply on one policy date.                                                                                                                       |
+| leaf               | A final value in a nested input or parameter structure, rather than a dictionary containing further entries.                                                                                                                     |
+| body check         | Running supported policy formulas with unit-carrying test values and comparing the result with the declared unit.                                                                                                                |
+| cast               | A local assertion that tells the checker to use a stated unit for one expression.                                                                                                                                                |
+| opt-out            | `verify_units=False` on one function. Its output declaration still applies, but its calculations are not checked.                                                                                                                |
 
 (gep-10-valuespec)=
 
@@ -505,6 +513,21 @@ rate, a probability, a person identifier, a category code, and a number of peopl
 use `DIMENSIONLESS` unless this GEP gives a more specific rule, such as a period on a
 rate or a group marker on a known count or indicator.
 
+For the restricted group-marker rules, TTSIM may record one narrow `QuantityKind`:
+`GENERIC`, `COUNT`, or `INDICATOR`. This information is not another public unit and does
+not generally distinguish economic meanings. It answers only whether one particular
+dimensionless declaration is independently known to be a count or yes/no indicator. Like
+any declaration supplied by an author, explicit `QuantityKind` metadata can be wrong; it
+does not prove the economic meaning of the underlying data.
+
+The evidence is local. A scalar function or input, one leaf of a mapping, each input
+axis of a raw parameter table or converted schedule, the schedule output, and each
+occurrence of a field in a nested structured value are separate declarations. Evidence
+for one of them MUST NOT authorize another. In particular, a count description on a
+parent object or sibling leaf does not authorize a category leaf; a count axis does not
+authorize another schedule axis; and evidence at one occurrence of a reused nested type
+does not authorize a different occurrence.
+
 A successful unit check therefore does not show that an identifier was never multiplied
 by a share or that two identifiers refer to the same kind of entity. Such checks would
 require a separate system for economic meaning and data relations.
@@ -558,13 +581,21 @@ check whether such repeated values are aligned with the correct rows.
 
 Declaration validation MUST enforce the following restriction. A direct
 `DIMENSIONLESS.PER_<LEVEL>` declaration is allowed only for a count or yes/no indicator
-whose meaning is established independently of its unit. Generated `COUNT`, the sum of a
-yes/no indicator, `ANY`, and `ALL` qualify automatically. A directly declared integer
-value may qualify as a count when the function documents that interpretation, although
-an integer return type alone does not distinguish a count from an identifier or category
-code. A floating-point share, probability, or ordinary rate with a group marker is
-rejected. If TTSIM cannot establish one of the permitted cases, it MUST reject the
-declaration rather than guess.
+whose meaning is established independently of its unit **for that exact declaration**.
+Generated `COUNT`, the sum of a yes/no indicator, `ANY`, and `ALL` qualify
+automatically. A Boolean return type establishes an indicator. A directly declared
+integer value may qualify as a count when its own name, documentation, or explicit
+`QuantityKind.COUNT` metadata states that interpretation unambiguously, although an
+integer return type alone does not distinguish a count from an identifier or category
+code.
+
+Evidence MUST NOT be borrowed from an enclosing object, sibling mapping leaf, another
+schedule axis, the schedule output, or another occurrence of the same nested structured
+type. General descriptions such as “number of children and rent class” do not establish
+that both components are counts. A floating-point share, probability, identifier,
+category, or ordinary rate with a group marker is rejected. If TTSIM cannot establish
+one of the permitted cases for the exact declaration carrying the marker, it MUST reject
+the declaration rather than guess.
 
 #### Restricted group calculations
 
@@ -613,6 +644,52 @@ familie__anzahl_personen_sn * sparerfreibetrag_y
 If a policy deliberately transfers an amount from one group concept to another, the
 function must use a local cast or an explicitly declared aggregation. TTSIM does not
 infer how households, Bedarfsgemeinschaften, tax units, and other groups overlap.
+
+(gep-10-booleans)=
+
+### Conditions
+
+Policy formulas use conditions to choose between alternatives. GEP 10 does not assign a
+separate unit to yes/no values and does not attempt to distinguish the different
+meanings of dimensionless values.
+
+For conditions, TTSIM therefore applies only a **dimensional screen**. It rejects a
+value if it has a physical unit or a period. A value that passes this screen may be a
+yes/no value, an identifier, a count, a share, a category code, or another dimensionless
+scalar. Passing the screen means only that units do not rule out its use as a condition.
+It does not establish which of these meanings the value has.
+
+When a comparison or logical operation produces a yes/no result, TTSIM may use that fact
+when checking later operations. This information comes from the operation that produced
+the result, not from its `DIMENSIONLESS` unit.
+
+The same dimensional screen MUST apply to:
+
+- Python `if` statements and conditional expressions;
+- `bool(value)` calls made while branches are checked;
+- supported uses of Python `and`, `or`, and `not`, and of `&`, `|`, `^`, and `~` in
+  formulas written for array-valued calculation; and
+- the `condition` argument of `xnp.where`.
+
+The following function is invalid because `wealth` is an amount of money:
+
+```python
+@policy_function(unit=TTSIMUnit.CURRENCY)
+def invalid(wealth: float) -> float:
+    return wealth if wealth else 0.0
+```
+
+`xnp.where` MUST check its condition as well as the two possible results. Rewriting a
+scalar conditional as an array-valued `xnp.where` must not remove this check.
+
+When two yes/no results carry the same group marker, the result keeps that marker. If
+one is person-level and one is group-level, or if their group markers differ, the result
+is treated as person-level because the logical operation is evaluated row by row. This
+is a practical unit rule; it does not establish that the underlying rows are aligned.
+
+Ordering comparisons such as `<` and `>=` require compatible units and produce a
+dimensionless yes/no result. Equality comparisons do not compare units, for the reasons
+given in {ref}`Trade-offs and limitations <gep-10-limitations>`.
 
 (gep-10-hours)=
 
@@ -723,8 +800,9 @@ that date.
 
 #### Schedules and lookup tables
 
-A schedule or lookup table has an input unit and an output unit. This is the same idea
-as stating the unit of both the running variable and the result of a tax schedule.
+A schedule or lookup table has one or more input axes and one output. Declaring their
+units is the same idea as stating the unit of every running variable and of the result
+of a tax schedule.
 
 ```yaml
 freibetrag_bei_behinderung_gestaffelt_y:
@@ -738,13 +816,19 @@ For a parameter type that requires `input_unit:` and `output_unit:`, the file-fo
 rules reject a single `unit:` declaration. A time suffix in the parameter name describes
 the output and must agree with `output_unit`.
 
+For a raw parameter table or converted schedule with several input axes, the units are
+ordered exactly like the arguments of the lookup call. Each axis is checked separately.
+If a dimensionless group-marked axis needs count or indicator evidence, that evidence
+belongs to the same position and to no other axis. The output has its own, separate
+evidence.
+
 #### Parameter functions
 
 A `@param_function` converts a raw YAML parameter of type `require_converter` into the
 object used by policy functions. Its declaration describes the converted object.
 
-A parameter function that produces a schedule declares the unit of the schedule's input
-and output:
+A parameter function that produces a schedule declares the unit of every input axis and
+of the output:
 
 ```python
 @param_function(
@@ -757,12 +841,44 @@ and output:
 def tarif() -> PiecewisePolynomialParamValue: ...
 ```
 
+A lookup table may have several input axes. Suppose the first axis is a household head
+count and the second is a rent class. Only the first may carry the household group
+marker and count evidence:
+
+```python
+from gettsim.tt import InputOutputUnits, QuantityKind, TTSIMUnit
+
+
+@param_function(
+    unit=InputOutputUnits(
+        input_unit=(
+            TTSIMUnit.DIMENSIONLESS.PER_HH,
+            TTSIMUnit.DIMENSIONLESS,
+        ),
+        output_unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_HH,
+        input_kind=(
+            QuantityKind.COUNT,
+            QuantityKind.GENERIC,
+        ),
+    ),
+    verify_units=False,
+)
+def maximum_rent_m_hh() -> ConsecutiveIntLookupTableParamValue: ...
+```
+
+If `input_unit` is a tuple, a non-generic `input_kind` MUST be a tuple of the same
+length and is interpreted position by position. A scalar `QuantityKind.COUNT` or
+`QuantityKind.INDICATOR` MUST NOT be repeated automatically across several input axes.
+The default `QuantityKind.GENERIC` MAY stand for all-generic axes. `output_kind` applies
+only to the output and MUST NOT authorize an input axis. An arity mismatch is a
+declaration error.
+
 The explicit opt-out applies to the code that constructs the schedule object, which is
 not an ordinary numerical policy formula. It does not remove the schedule's unit
-contract: for every supported `look_up` or `piecewise_polynomial` call, TTSIM checks the
-input variable against the schedule's input unit and assigns the declared output unit to
-the result. The construction body is nevertheless listed as unchecked in the validation
-report.
+contract: for every supported `look_up` or `piecewise_polynomial` call, TTSIM checks
+each input variable against the corresponding input axis and assigns the declared output
+unit to the result. The construction body is nevertheless listed as unchecked in the
+validation report.
 
 A structured parameter may use `unit=UNSET_UNIT` only when the object as a whole has no
 single unit and every field that carries a quantity has its own annotation.
@@ -793,6 +909,16 @@ prove that the parameter-conversion function maps each raw YAML value into an ou
 field with the intended unit, even when the names coincide, because such a function may
 deliberately rename or transform values. That mapping therefore remains a matter for
 focused tests and policy review.
+
+Every path through a structured value is validated separately. If the same nested
+dataclass type appears under two different fields, TTSIM MUST visit both occurrences and
+must not stop after validating the type once. Evidence from an outer field name or
+description belongs only to that occurrence. Evidence written directly in the nested
+field's type annotation applies to every occurrence of that field because it is part of
+the type itself. Reusing a generic nested type for economically different values does
+not permit one occurrence—for example, a number of children—to authorize another—for
+example, a rent class or identifier. Every annotated field is checked even if no policy
+formula reads it.
 
 (gep-10-generated)=
 
@@ -903,20 +1029,20 @@ lacks enough information to certify their result level.
 
 #### Declaration matrix
 
-| Object                               | Required declaration                             | Currency                         | What TTSIM checks                                                                            |
-| ------------------------------------ | ------------------------------------------------ | -------------------------------- | -------------------------------------------------------------------------------------------- |
-| `@policy_function`                   | `unit=`                                          | abstract `CURRENCY` for money    | declaration, suffixes, and supported cases in the body                                       |
-| `@policy_input`                      | `unit=`                                          | abstract `CURRENCY` for money    | declaration and suffixes                                                                     |
-| scalar or dictionary parameter       | `unit:`                                          | concrete currency for money      | file format, suffix, and statutory currency                                                  |
-| schedule or lookup parameter         | `input_unit:` and `output_unit:`                 | concrete currency where relevant | file format and both units                                                                   |
-| structured `@param_function`         | `unit=UNSET_UNIT`                                | units on fields                  | field use and matching YAML leaves                                                           |
-| schedule-producing `@param_function` | `InputOutputUnits(...)` and `verify_units=False` | abstract `CURRENCY` in code      | input and output units at schedule calls                                                     |
-| generated period conversion          | automatic                                        | inherited                        | target period from the suffix                                                                |
-| generated aggregation                | automatic                                        | inherited                        | aggregation rule and target level                                                            |
-| hand-written aggregation             | `unit=`                                          | abstract `CURRENCY` in code      | exact derived unit unless opted out                                                          |
-| group-creation function              | required or generated `DIMENSIONLESS`            | not applicable                   | declaration only                                                                             |
-| rounding specification               | unit required for monetary magnitudes            | concrete currency                | function unit and statutory currency                                                         |
-| unit-annotated input                 | unit on every leaf in this mode                  | concrete source currency         | known unit, suffix period, physical measure and scale, group marker, and currency conversion |
+| Object                               | Required declaration                             | Currency                         | What TTSIM checks                                                                                |
+| ------------------------------------ | ------------------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `@policy_function`                   | `unit=`                                          | abstract `CURRENCY` for money    | declaration, suffixes, and supported cases in the body                                           |
+| `@policy_input`                      | `unit=`                                          | abstract `CURRENCY` for money    | declaration and suffixes                                                                         |
+| scalar or dictionary parameter       | `unit:`                                          | concrete currency for money      | file format, suffix, and statutory currency                                                      |
+| schedule or lookup parameter         | `input_unit:` and `output_unit:`                 | concrete currency where relevant | file format, axis order, and every input/output unit                                             |
+| structured `@param_function`         | `unit=UNSET_UNIT`                                | units on fields                  | every complete field path and matching YAML leaves                                               |
+| schedule-producing `@param_function` | `InputOutputUnits(...)` and `verify_units=False` | abstract `CURRENCY` in code      | each input axis and the output separately, including exact count/indicator evidence where needed |
+| generated period conversion          | automatic                                        | inherited                        | target period from the suffix                                                                    |
+| generated aggregation                | automatic                                        | inherited                        | aggregation rule and target level                                                                |
+| hand-written aggregation             | `unit=`                                          | abstract `CURRENCY` in code      | exact derived unit unless opted out                                                              |
+| group-creation function              | required or generated `DIMENSIONLESS`            | not applicable                   | declaration only                                                                                 |
+| rounding specification               | unit required for monetary magnitudes            | concrete currency                | function unit and statutory currency                                                             |
+| unit-annotated input                 | unit on every leaf in this mode                  | concrete source currency         | known unit, suffix period, physical measure and scale, group marker, and currency conversion     |
 
 `UNSET_UNIT` is only for a structured result that has no single unit. For ordinary
 parameters, functions, and aggregations, a missing unit declaration is an error.
@@ -1145,7 +1271,10 @@ The checker rejects, among other things:
 - an array reduction whose target level cannot be determined;
 - a join with a key carrying a physical unit or a fallback with the wrong unit;
 - a numerical field from a structured parameter that lacks a unit;
-- a schedule called with the wrong input unit or assigned the wrong output unit; and
+- a group-marked dimensionless leaf, field occurrence, or schedule axis whose own
+  count/indicator meaning is not established;
+- a schedule called with the wrong input unit, wrong input-axis order or arity, or wrong
+  output unit; and
 - an operation for which TTSIM has no faithful unit rule, unless the function explicitly
   opts out.
 
@@ -1251,8 +1380,11 @@ latter removes body coverage.
 **Different dimensionless meanings are usually not checked.** Shares, identifiers,
 category codes, counts, yes/no values, rates without a period, and ordinary scalars all
 use `DIMENSIONLESS`. TTSIM generally cannot reject calculations that confuse these
-meanings. For conditions, it only screens out values with physical units or periods;
-passing that screen does not establish the meaning of the remaining dimensionless value.
+meanings. `QuantityKind` provides only the narrow, local evidence needed for a
+dimensionless group marker; it is not a general semantic type and does not make other
+arithmetic between dimensionless values safe. For conditions, TTSIM only screens out
+values with physical units or periods; passing that screen does not establish the
+meaning of the remaining dimensionless value.
 
 **Equality does not compare units.** This permits useful sentinel comparisons such as
 `p_id_empfänger == -1`. It also means that the checker does not catch an equality
@@ -1339,6 +1471,12 @@ An implementation conforms to this GEP only if all of the following hold:
 
 1. every object that requires a unit has a valid declaration;
 1. a group marker on a dimensionless value is limited to a known count or indicator;
+1. the count/indicator evidence belongs to the exact scalar, mapping leaf, raw or
+   converted schedule input axis, schedule output, or structured-field occurrence
+   carrying the group marker; it is not borrowed from a sibling, parent description,
+   another axis, or another occurrence of a reused nested type;
+1. tuple-valued schedule inputs use positionally matched kind evidence of the same
+   arity, and a non-generic scalar kind is not broadcast across several axes;
 1. unsupported products, ratios, and calculations across group levels are rejected;
 1. `MEAN`, `MIN`, and `MAX` produce a result at the target group level;
 1. scalar conditions and `xnp.where` reject values with physical units or periods;
@@ -1361,8 +1499,10 @@ Passing the ordinary project tests is not enough to demonstrate these requiremen
 implementation tests SHOULD deliberately introduce a mistake for every rule. Examples
 include returning a stock where a flow is declared, using money as a condition, passing
 an invalid condition to `xnp.where`, using a fallback with the wrong unit in a join,
-marking a share as a group total, treating a group mean as person-level, and omitting a
-date on which only a parameter or currency changes.
+marking a share as a group total, letting a count axis authorize a rent-class axis,
+letting one nested occurrence authorize another occurrence of the same dataclass type,
+treating a group mean as person-level, and omitting a date on which only a parameter or
+currency changes.
 
 ## Related work
 
@@ -1402,6 +1542,9 @@ requirements added by this revision:
 
 - reject group-level shares and rates while retaining the documented group counts and
   indicators;
+- attach count/indicator evidence to the exact declaration it authorizes, including each
+  schedule axis and each occurrence of a nested structured field, without broadcasting a
+  non-generic kind or reusing evidence from siblings and repeated types;
 - restrict general products and ratios between group-marked quantities;
 - keep `MEAN` at the target group level rather than treating it as person-level;
 - report casts, whole-body opt-outs, and every other body that could not be checked


### PR DESCRIPTION
## Summary

GEP 10 specifies how TTSIM and GETTSIM declare and check units for tax-and-transfer calculations. The text is written for economists familiar with policy rules and ordinary data management, while stating precisely what the checker does and does not establish.

The GEP covers:

- compositional Pint units for physical quantities, reference periods, currencies, and selected group-level quantities;
- explicit `COUNT` and `INDICATOR` declarations for hand-written dimensionless counts and yes/no indicators, including mapping leaves, schedule axes and outputs, structured fields, and local casts;
- automatic recognition of generated `COUNT`, Boolean `SUM`, `ANY`, and `ALL` calculations;
- restricted group arithmetic for totals, head counts, indicators, and person-level allocations, without treating group markers as a complete model of data levels or alignment;
- body checks for supported policy expressions, including conditions, `xnp.where`, joins, aggregations, and reductions;
- calendar points, calendar ordinals, durations, reference-period conversions, statutory currencies, and conversion at the input/output boundary;
- validation over every relevant policy-date regime; and
- separate reporting of resolved declarations, checked bodies, generated rules, casts, whole-body opt-outs, unsupported bodies, and other unchecked bodies.

## Scope and guarantees

A successful body check means that every supported operation examined by TTSIM used compatible units and produced the declared result unit. It is not a proof of arbitrary Python, legal correctness, data alignment, or the economic meaning of otherwise dimensionless values.

`COUNT` and `INDICATOR` remain dimensionless for Pint arithmetic. Their explicit spelling supplies only the narrow semantic information needed for the documented group calculations. Names, qualified names, and docstrings do not establish that a number is a count or indicator.

Unsupported unit-relevant operations fail closed or require a visible exception. Policy packages keep exact reviewed baselines for local casts and body opt-outs in continuous integration; additions, removals, and substitutions require an explicit baseline update, while unsupported bodies must remain empty.

## Related implementation

- [TTSIM #151](https://github.com/ttsim-dev/ttsim/pull/151) implements the checker changes and the public `COUNT` / `INDICATOR` declaration syntax.
- [GETTSIM #1212](https://github.com/ttsim-dev/gettsim/pull/1212) applies the declarations to the German policy system and adds the CI guard against growth in casts and opt-outs.

## Verification

- `pixi run prek run --all-files`
- Read the Docs build for this PR
- All existing MyST cross-reference labels remain available.

## Additional branch change

The branch also updates the `.ai-instructions` submodule. This change is independent of the GEP text.
