### PR TITLE
Fix law references for the Regelaltersgrenze

### DIFF
--- a/src/gettsim/germany/sozialversicherung/rente/altersrente/regelaltersrente/altersgrenze.yaml
+++ b/src/gettsim/germany/sozialversicherung/rente/altersrente/regelaltersrente/altersgrenze.yaml
@@ -17,8 +17,23 @@ altersgrenze:
   unit: YEARS
   type: scalar
   1957-02-26:
-    reference: Rentenreformgesetz 1957 BGBl. I S. 88
+    reference: >-
+      Artikel 1 G. v. 23.02.1957 BGBl. I S. 45 (ArVNG).
+      Artikel 1 G. v. 23.02.1957 BGBl. I S. 88 (AnVNG).
+    note: >-
+      Uniform age limit, enacted the same day by two parallel laws: the ArVNG for
+      blue-collar workers (§ 1248 Abs. 1 RVO, BGBl. I S. 45) and the AnVNG for
+      white-collar workers (§ 25 Abs. 1 AVG, BGBl. I S. 88). Identical wording in
+      both: "Altersruhegeld erhält der Versicherte, der das 65. Lebensjahr vollendet
+      hat, wenn die Wartezeit erfüllt ist."
     value: 65.0
+  1992-01-01:
+    value: 65.0
+    reference: Artikel 1 G. v. 18.12.1989 BGBl. I S. 2261 (RRG 1992).
+    note: >-
+      Recodification into the SGB VI: the age limit moves from § 1248 Abs. 5 RVO
+      (blue-collar) and § 25 Abs. 5 AVG (white-collar) into the unified
+      § 35 Satz 2 SGB VI. Value unchanged.
   2007-04-19:
     note: >-
       Increase of the early retirement age from 65 to 67 for birth cohort 1947-1964. See
@@ -45,7 +60,9 @@ altersgrenze_gestaffelt:
   output_unit: YEARS
   type: year_based_phase_inout_of_age_thresholds
   2007-04-20:
-    reference: RV-Altersgrenzenanpassungsgesetz 20.04.2007. BGBl. I S. 554
+    reference: >-
+      Artikel 1 G. v. 20.04.2007 BGBl. I S. 554
+      (RV-Altersgrenzenanpassungsgesetz).
     note: >-
       Increase of the early retirement age from 65 to 67 for birth cohort 1947-1964.
       Vertrauensschutz (Art. 56) applies for birth cohorts before 1955 who were in


### PR DESCRIPTION
### What problem do you want to solve?

This PR adds minor fixes to the law references for the Regelaltersgrenze

References only. No values changed, no behaviour change.

- 1957 cited Rentenreformgesetz 1957 BGBl. I S. 88. S. 88 is the AnVNG, which amended the AVG for white-collar workers. The parallel law for blue-collar workers, § 1248 RVO, is in the ArVNG on S. 45. Both laws are now cited, because the parameter applies one uniform age limit to both groups. Verified against the BGBl. full text via offenegesetze.de.
- 2007 just reformatted to the GEP-03 style.
- New `1992-01-01` key. The value stays 65, but the legal basis moved.

### points to decide

- The 1992 entry adds a date key for an unchanged value. GEP-03 does not ask for this. Happy to drop it if you would rather keep references only where the value changes.
- There are probably a lot of parallel policy functions and parameters for white-collar workers and blue-collar workers. Most are the same but obviously there could be differences. GETTSIM does not differentiate. An alternative would be to have two parameters, one for each group (and treat groups differently).
